### PR TITLE
Fix issue #158.

### DIFF
--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -23,9 +23,9 @@ export function uiField(context, presetField, entityIDs, options) {
 
     // Don't show the remove and revert buttons if any of the entity IDs are FB features
     // with source=digitalglobe or source=maxar
-    var someFbRoadsSelected = entityIDs.some(function(entity) {
+    var someFbRoadsSelected = entityIDs ? entityIDs.some(function(entity) {
             return entity.__fbid__ && (entity.tags.source === 'maxar' || entity.tags.source === 'digitalglobe');
-        });
+        }) : false;
 
 
     if ( someFbRoadsSelected ) {


### PR DESCRIPTION
During the rebase to 2.18.4, multi-tag-edits were made possible, which involved a lot of extra code for maintaining the edits across several entity IDs. This bug crept in while I was readjusting the 'are any AI roads selected' and it wasn't checking for null entityIDs as it should have been. 

#158 fix