### PR TITLE
add distinctive styling for highway=path back, fixes #811

### DIFF
--- a/modules/pixi/styles.js
+++ b/modules/pixi/styles.js
@@ -124,7 +124,7 @@ const STYLES = {
     stroke: { width: 5, color: 0x998888, dash: [8, 8], cap: PIXI.LINE_CAP.BUTT }
   },
   path: {
-    casing: { width: 5, color: 0xffffff },
+    casing: { width: 5, color: 0xddccaa },
     stroke: { width: 3, color: 0x998888, dash: [6, 6], cap: PIXI.LINE_CAP.BUTT }
   },
   footway: {


### PR DESCRIPTION
This adds back the brown casing for `highway=path` ways

top: new, bottom: old


![SCR-20230328-rzkx](https://user-images.githubusercontent.com/120452/228414663-1833092a-1c4a-475d-9d8d-e3e7a14bd23d.jpeg)
