### PR TITLE
Add green line styling for ridges back

### DIFF
--- a/modules/pixi/styles.js
+++ b/modules/pixi/styles.js
@@ -164,6 +164,9 @@ const STYLES = {
     casing: { width: 7, color: 0x444444 },
     stroke: { width: 5, color: 0x77dddd }
   },
+  ridge: {
+    stroke: { width: 2, color: 0x8cd05f}  // rgb(140, 208, 95)
+  },
 
   runway: {
     casing: { width: 10, color: 0x000000, cap: PIXI.LINE_CAP.BUTT },
@@ -347,6 +350,7 @@ const STYLE_SELECTORS = {
     cave_entrance: 'darkgray',
     cliff: 'darkgray',
     glacier: 'lightgray',
+    ridge: 'ridge',
     rock: 'darkgray',
     sand: 'yellow',
     scree: 'darkgray',


### PR DESCRIPTION
This fixes #810 
* Add new stroke style for ridges
* Add `ridge` entry to `natural` selector key

Before 

![SCR-20230329-ilux](https://user-images.githubusercontent.com/120452/228597361-dd6d3510-7ffc-469e-a363-0eecd8dc3173.png)

After

![SCR-20230329-ills](https://user-images.githubusercontent.com/120452/228597411-bf7dce9f-eca3-4eff-9e74-48d2d25ab31b.png)

