### PR TITLE
PMTiles + enhancements to vector tile data sources in Rapid

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2678,240 +2678,207 @@ img.tag-reference-wiki-image {
 }
 
 
-/* OSM Note / QA Editors
+/* OSM Note / QA Editors / Custom Data Editor
 ------------------------------------------------------- */
+.data-header,
 .note-header,
 .qa-header {
-    background-color: #f6f6f6;
-    border-radius: 5px;
-    border: 1px solid #ccc;
-    display: flex;
-    flex-flow: row nowrap;
-    align-items: center;
+  background-color: #f6f6f6;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
 }
 
+.data-header-icon,
 .note-header-icon,
 .qa-header-icon {
-    background-color: #fff;
-    padding: 10px;
-    flex: 0 0 auto;
-    position: relative;
-    width: 60px;
-    height: 60px;
-    border-right: 1px solid #ccc;
-    border-radius: 5px 0 0 5px;
+  background-color: #fff;
+  padding: 10px;
+  flex: 0 0 auto;
+  position: relative;
+  width: 60px;
+  height: 60px;
+  border-right: 1px solid #ccc;
+  border-radius: 5px 0 0 5px;
 }
+.ideditor[dir='rtl'] .data-header-icon,
 .ideditor[dir='rtl'] .note-header-icon,
 .ideditor[dir='rtl'] .qa-header-icon {
-    border-right: unset;
-    border-left: 1px solid #ccc;
-    border-radius: 0 5px 5px 0;
+  border-right: unset;
+  border-left: 1px solid #ccc;
+  border-radius: 0 5px 5px 0;
 }
 
+.data-header-icon .icon-wrap,
 .note-header-icon .icon-wrap,
 .qa-header-icon .icon-wrap {
-    position: absolute;
-    top: 0px;
+  position: absolute;
+  top: 0px;
 }
 
 .preset-icon-28 {
-    position: absolute;
-    top: 16px;
-    left: 16px;
-    margin: auto;
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  margin: auto;
 }
 .preset-icon-28 .icon {
-    width: 28px;
-    height: 28px;
+  width: 28px;
+  height: 28px;
 }
 
+.data-header-label,
 .note-header-label,
 .qa-header-label {
-    background-color: #f6f6f6;
-    padding: 0 15px;
-    flex: 1 1 100%;
-    font-size: 14px;
-    font-weight: bold;
-    border-radius: 0 5px 5px 0;
+  background-color: #f6f6f6;
+  padding: 0 15px;
+  flex: 1 1 100%;
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 0 5px 5px 0;
 }
+.ideditor[dir='rtl'] .data-header-label,
 .ideditor[dir='rtl'] .note-header-label,
 .ideditor[dir='rtl'] .qa-header-label {
-    border-radius: 5px 0 0 5px;
+  border-radius: 5px 0 0 5px;
 }
 
 .note-category {
-    margin: 20px 0px;
+  margin: 20px 0px;
 }
 
 .comments-container {
-    background: #ececec;
-    padding: 1px 10px;
-    border-radius: 8px;
-    margin-top: 20px;
+  background: #ececec;
+  padding: 1px 10px;
+  border-radius: 8px;
+  margin-top: 20px;
 }
 
 .comment {
-    background-color: #fff;
-    border-radius: 5px;
-    border: 1px solid #ccc;
-    margin: 10px auto;
-    display: flex;
-    flex-flow: row nowrap;
+  background-color: #fff;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  margin: 10px auto;
+  display: flex;
+  flex-flow: row nowrap;
 }
 .comment-avatar {
-    padding: 10px;
-    flex: 0 0 auto;
+  padding: 10px;
+  flex: 0 0 auto;
 }
 .comment-avatar .icon.comment-avatar-icon {
-    width: 40px;
-    height: 40px;
-    object-fit: cover;
-    border: 1px solid #ccc;
-    border-radius: 20px;
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border: 1px solid #ccc;
+  border-radius: 20px;
 }
 .comment-main {
-    padding: 10px 10px 10px 0;
-    flex: 1 1 100%;
-    flex-flow: column nowrap;
-    overflow: hidden;
-    overflow-wrap: break-word;
+  padding: 10px 10px 10px 0;
+  flex: 1 1 100%;
+  flex-flow: column nowrap;
+  overflow: hidden;
+  overflow-wrap: break-word;
 }
 .ideditor[dir='rtl'] .comment-main {
-    padding: 10px 0 10px 10px;
+  padding: 10px 0 10px 10px;
 }
 
 .comment-metadata {
-    flex-flow: row nowrap;
-    justify-content: space-between;
+  flex-flow: row nowrap;
+  justify-content: space-between;
 }
 .comment-author {
-    font-weight: bold;
-    color: #333;
+  font-weight: bold;
+  color: #333;
 }
 .comment-date {
-    color: #aaa;
+  color: #aaa;
 }
 .comment-text {
-    color: #333;
-    margin-top: 10px;
-    overflow-y: auto;
-    max-height: 250px;
+  color: #333;
+  margin-top: 10px;
+  overflow-y: auto;
+  max-height: 250px;
 }
 .comment-text::-webkit-scrollbar {
-    border-left: none;
+  border-left: none;
 }
 
 .note-save,
 .qa-save {
-    padding-top: 20px;
+  padding-top: 20px;
 }
 
 .qa-details-container {
-    background: #ececec;
-    padding: 10px;
-    margin-top: 20px;
-    border-radius: 4px;
-    border: 1px solid #ccc;
-    display: flex;
-    flex-direction: column;
+  background: #ececec;
+  padding: 10px;
+  margin-top: 20px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
 }
 .qa-details-description-text::first-letter {
-    text-transform: capitalize;
+  text-transform: capitalize;
 }
 .ideditor[dir='rtl'] .qa-details-description-text::first-letter {
-    text-transform: none;  /* #5877 */
+  text-transform: none;  /* iD#5877 */
 }
 .qa-details-subsection h4 {
-    padding-bottom: 2px;
+  padding-bottom: 2px;
 }
 .qa-details-subsection:not(:last-child) {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 .qa-details-subsection:empty {
-    display: none;
+  display: none;
 }
 
 .note-save .new-comment-input,
 .qa-save .new-comment-input {
-    width: 100%;
-    height: 100px;
-    max-height: 300px;
-    min-height: 100px;
+  width: 100%;
+  height: 100px;
+  max-height: 300px;
+  min-height: 100px;
 }
 
 .note-save .detail-section,
 .qa-save .detail-section {
-    margin: 10px 0;
+  margin: 10px 0;
 }
 
 .note-report {
-    float: right;
+  float: right;
 }
 
 .qa-header-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .qa-header-icon .qaItem {
   scale: 1.8;
 }
 
+/* data editor contains a custom raw-tag-editor without info/add/delete buttons */
+.data-tag-editor {
+  padding: 20px;
+}
+.data-tag-editor button.add-tag,
+.data-tag-editor .tag-row button {
+  display: none;
+}
+.data-tag-editor .tag-row .key-wrap,
+.data-tag-editor .tag-row .value-wrap {
+  width: 50%;
+}
 
-/* Custom Data Editor
+
+/* Over Map
 ------------------------------------------------------- */
-.data-header {
-    background-color: #f6f6f6;
-    border-radius: 5px;
-    border: 1px solid #ccc;
-    display: flex;
-    flex-flow: row nowrap;
-    align-items: center;
-}
-
-.data-header-icon {
-    background-color: #fff;
-    padding: 10px;
-    flex: 0 0 auto;
-    position: relative;
-    width: 60px;
-    height: 60px;
-    border-right: 1px solid #ccc;
-    border-radius: 5px 0 0 5px;
-}
-.ideditor[dir='rtl'] .data-header-icon {
-    border-right: unset;
-    border-left: 1px solid #ccc;
-    border-radius: 0 5px 5px 0;
-}
-
-.data-header-icon .icon-wrap {
-    position: absolute;
-    top: 0px;
-}
-
-.data-header-label {
-    background-color: #f6f6f6;
-    padding: 0 15px;
-    flex: 1 1 100%;
-    font-size: 14px;
-    font-weight: bold;
-    border-radius: 0 5px 5px 0;
-}
-.ideditor[dir='rtl'] .data-header-label {
-    border-radius: 5px 0 0 5px;
-}
-
-/* custom data editor - no info/delete buttons */
-.data-editor.raw-tag-editor .tag-row button {
-    display: none;
-}
-.data-editor.raw-tag-editor .tag-row .key-wrap,
-.data-editor.raw-tag-editor .tag-row .value-wrap {
-    width: 50%;
-}
-
-
 .over-map {
     position: relative;
     height: 100%;

--- a/modules/behaviors/AbstractBehavior.js
+++ b/modules/behaviors/AbstractBehavior.js
@@ -127,7 +127,7 @@ export class AbstractBehavior extends EventEmitter {
         layer: feature.layer,
         layerID: feature.layer.id,
         data: feature.data,
-        dataID: feature.data?.id
+        dataID: feature.dataID
       };
       return result;
     }
@@ -143,7 +143,7 @@ export class AbstractBehavior extends EventEmitter {
         layer: feature.layer,
         layerID: feature.layer.id,
         data: feature.data,
-        dataID: feature.data?.id
+        dataID: feature.dataID
       };
       return result;
     }

--- a/modules/behaviors/SelectBehavior.js
+++ b/modules/behaviors/SelectBehavior.js
@@ -305,10 +305,11 @@ export class SelectBehavior extends AbstractBehavior {
 
     // Determine what we clicked on and switch modes..
     const target = eventData.target;
-    let datum = target && target.data;
+    let data = target?.data;
+    let dataID = target?.dataID;
 
-    // If we're clicking on something, we want to pause doubleclick zooms
-    if (datum) {
+    // If we're clicking on something real, we want to pause doubleclick zooms
+    if (data) {
       const behavior = this.context.behaviors['map-interaction'];
       behavior.doubleClickEnabled = false;
       window.setTimeout(() => behavior.doubleClickEnabled = true, 500);
@@ -316,12 +317,13 @@ export class SelectBehavior extends AbstractBehavior {
 
     // Clicked a midpoint..
     // Treat a click on a midpoint as if clicking on its parent way
-    if (datum && datum.type === 'midpoint') {
-      datum = datum.way;
+    if (data?.type === 'midpoint') {
+      data = data.way;
+      dataID = data.id;
     }
 
     // Clicked on nothing
-    if (!datum) {
+    if (!data) {
       context.systems.photos.selectPhoto(null);
       if (context.mode?.id !== 'browse' && !this._multiSelection.size) {
         context.enter('browse');
@@ -331,70 +333,63 @@ export class SelectBehavior extends AbstractBehavior {
 
     // Clicked a non-OSM feature..
     if (
-      datum.__fbid__ || // Clicked a Rapid feature..
-      datum.__featurehash__ || // Clicked Custom Data (e.g. gpx track)
-      datum instanceof osmNote || // Clicked an OSM Note...
-      datum instanceof QAItem // Clicked a QA Item (keepright, osmose, improveosm)...
+      data.__fbid__ ||            // Clicked a Rapid feature..
+      data.__featurehash__ ||     // Clicked Custom Data (e.g. gpx track)
+      data instanceof osmNote ||  // Clicked an OSM Note...
+      data instanceof QAItem      // Clicked a QA Item (keepright, osmose, improveosm)...
     ) {
-      const selection = new Map().set(datum.id, datum);
+      const selection = new Map().set(dataID, data);
       context.enter('select', { selection: selection });
       return;
     }
 
     // Clicked an OSM feature..
-    if (datum instanceof osmEntity) {
+    if (data instanceof osmEntity) {
       let selectedIDs = context.selectedIDs();
 
       if (!isMultiselect) {
-        if (
-          !this._showsMenu ||
-          selectedIDs.length <= 1 ||
-          selectedIDs.indexOf(datum.id) === -1
-        ) {
+        if (!this._showsMenu || selectedIDs.length <= 1 || !selectedIDs.includes(dataID)) {
           // Always re-enter select mode even if the entity is already
           // selected since listeners may expect `context.enter` events,
           // e.g. in the walkthrough
-          context.enter('select-osm', { selectedIDs: [datum.id] });
+          context.enter('select-osm', { selectedIDs: [dataID] });
         }
 
       } else {
-        if (selectedIDs.indexOf(datum.id) !== -1) {
-          // clicked entity is already in the selectedIDs list..
+        if (selectedIDs.includes(dataID)) {   // already in the selectedIDs..
           if (!this._showsMenu) {
-            // deselect clicked entity, then reenter select mode or return to browse mode..
-            selectedIDs = selectedIDs.filter(id => id !== datum.id);
+            selectedIDs = selectedIDs.filter(id => id !== dataID);      // deselect it..
             context.enter('select-osm', { selectedIDs: selectedIDs });
           }
-        } else {
-          // clicked entity is not in the selected list, add it..
-          selectedIDs = selectedIDs.concat([datum.id]);
+        } else {                         // not already in selectedIDs...
+          selectedIDs.push([dataID]);    // select it..
           context.enter('select-osm', { selectedIDs: selectedIDs });
         }
       }
     }
 
     // Clicked on a photo, so open / refresh the viewer's pic
-    if (datum.captured_at) {
+    if (data.captured_at) {
       // Determine the layer that was clicked on, obtain its service.
-      const layerID = target.layer.id;
-      context.systems.map.centerEase(datum.loc);
-      context.systems.photos.selectPhoto(layerID, datum.id);
+      const layerID = target.layerID;
+      context.systems.map.centerEase(data.loc);
+      context.systems.photos.selectPhoto(layerID, dataID);
 //      // No mode change event here, just manually tell the renderer to select it, for now
 //      const scene = context.scene();
 //      scene.clearClass('selected');
-//      scene.classData(layerID, datum.id, 'selected');
+//      scene.classData(layerID, dataID, 'selected');
     }
 
     // Clicked on a Mapillary object detection or traffic sign..
     // Open the Mapillary viewer with an image showing that object/sign
-    if (datum.first_seen_at) {
+    if (data.first_seen_at) {
       const service = context.services.mapillary;
       if (!service?.started) return;
 
       context.systems.map.centerEase(event.loc);
       const selectedImageID = service.getActiveImage() && service.getActiveImage().id;
 
-      service.getDetectionsAsync(datum.id)
+      service.getDetectionsAsync(dataID)
         .then(detections => {
           if (!detections.length) return;
 
@@ -435,6 +430,7 @@ export class SelectBehavior extends AbstractBehavior {
       this._doContextMenu();
     }
   }
+
 
   /**
    * _doDoubleClick
@@ -502,8 +498,8 @@ export class SelectBehavior extends AbstractBehavior {
 
     } else {                 // menu is off, toggle it on
       // Only attempt to display the context menu if we're focused on a non-Rapid OSM Entity.
-        this._showsMenu = true;
-        context.systems.ui.showEditMenu(eventData.coord);
+      this._showsMenu = true;
+      context.systems.ui.showEditMenu(eventData.coord);
     }
   }
 

--- a/modules/core/PresetSystem.js
+++ b/modules/core/PresetSystem.js
@@ -5,7 +5,7 @@ import { osmNodeGeometriesForTags, osmSetAreaKeys, osmSetPointTags, osmSetVertex
 import { Category, Collection, Field, Preset } from './lib';
 import { uiFields } from '../ui/fields';
 
-const VERBOSE = true;        // warn about v6 preset featues we don't support currently
+const VERBOSE = true;        // warn about v6 preset features we don't support currently
 const MAXRECENTS = 30;       // how many recents to store in localstorage
 const MAXRECENTS_SHOW = 6;   // how many recents to show on the preset list
 

--- a/modules/core/UploaderSystem.js
+++ b/modules/core/UploaderSystem.js
@@ -341,7 +341,7 @@ export class UploaderSystem extends AbstractSystem {
     }
 
     function entityName(entity) {
-      return l10n.displayName(entity) || (l10n.displayType(entity.id) + ' ' + entity.id);
+      return l10n.displayName(entity.tags) || (l10n.displayType(entity.id) + ' ' + entity.id);
     }
 
     function sameVersions(local, remote) {

--- a/modules/pixi/AbstractFeature.js
+++ b/modules/pixi/AbstractFeature.js
@@ -65,6 +65,7 @@ export class AbstractFeature {
     this._label = null;
     this._labelDirty = true;
 
+    this._dataID = null;
     this._data = null;
 
     this._selected = false;
@@ -110,6 +111,8 @@ export class AbstractFeature {
     this.geometry = null;
     this._style = null;
     this._label = null;
+
+    this._dataID = null;
     this._data = null;
 
     this.sceneBounds = null;
@@ -316,6 +319,16 @@ export class AbstractFeature {
     return this._data;
   }
 
+  /**
+   * dataID
+   * Getter only, use `setData()` to change it.
+   * (because we need to know an id/key to identify the data by, and these can be anything)
+   * @readonly
+   */
+  get dataID() {
+    return this._dataID;
+  }
+
 
   /**
    * setData
@@ -324,8 +337,8 @@ export class AbstractFeature {
    * @param   data     `Object` data to bind to the feature (e.g. an OSM Node)
    */
   setData(dataID, data) {
+    this._dataID = dataID;
     this._data = data;
-    this.dataID = dataID;
     this.layer.bindData(this.id, dataID);
     this.dirty = true;
   }

--- a/modules/pixi/PixiLayerCustomData.js
+++ b/modules/pixi/PixiLayerCustomData.js
@@ -285,13 +285,13 @@ export class PixiLayerCustomData extends AbstractLayer {
     };
 
     for (const d of polygons) {
+      const dataID = d.id ? d.id : d.__featurehash__.toString();
       const parts = (d.geometry.type === 'Polygon') ? [d.geometry.coordinates]
         : (d.geometry.type === 'MultiPolygon') ? d.geometry.coordinates : [];
 
       for (let i = 0; i < parts.length; ++i) {
         const coords = parts[i];
-        const id = d.id ? d.id : d.__featurehash__.toString();
-        const featureID = `${this.layerID}-${id}-${i}`;
+        const featureID = `${this.layerID}-${dataID}-${i}`;
         let feature = this.features.get(featureID);
         const version = d.v || 0;
 
@@ -304,7 +304,7 @@ export class PixiLayerCustomData extends AbstractLayer {
         if (feature.v !== version) {
           feature.v = version;
           feature.geometry.setCoords(coords);
-          feature.setData(d.id, d);
+          feature.setData(dataID, d);
         }
 
         this.syncFeatureClasses(feature);
@@ -332,13 +332,13 @@ export class PixiLayerCustomData extends AbstractLayer {
     let style = styleOverride || LINE_STYLE;
 
     for (const d of lines) {
+      const dataID = d.id ? d.id : d.__featurehash__.toString();
       const parts = (d.geometry.type === 'LineString') ? [d.geometry.coordinates]
         : (d.geometry.type === 'MultiLineString') ? d.geometry.coordinates : [];
 
       for (let i = 0; i < parts.length; ++i) {
         const coords = parts[i];
-        const id = d.id ? d.id : d.__featurehash__.toString();
-        const featureID = `${this.layerID}-${id}-${i}`;
+        const featureID = `${this.layerID}-${dataID}-${i}`;
         let feature = this.features.get(featureID);
         const version = d.v || 0;
 
@@ -351,7 +351,7 @@ export class PixiLayerCustomData extends AbstractLayer {
         if (feature.v !== version) {
           feature.v = version;
           feature.geometry.setCoords(coords);
-          feature.setData(d.id, d);
+          feature.setData(dataID, d);
         }
 
         this.syncFeatureClasses(feature);
@@ -374,12 +374,13 @@ export class PixiLayerCustomData extends AbstractLayer {
     const POINT_STYLE = { markerTint: 0x00ffff };
 
     for (const d of points) {
+      const dataID = d.id ? d.id : d.__featurehash__.toString();
       const parts = (d.geometry.type === 'Point') ? [d.geometry.coordinates]
         : (d.geometry.type === 'MultiPoint') ? d.geometry.coordinates : [];
 
       for (let i = 0; i < parts.length; ++i) {
         const coords = parts[i];
-        const featureID = `${this.layerID}-${d.id}-${i}`;
+        const featureID = `${this.layerID}-${dataID}-${i}`;
         let feature = this.features.get(featureID);
 
         if (!feature) {
@@ -387,7 +388,7 @@ export class PixiLayerCustomData extends AbstractLayer {
           feature.geometry.setCoords(coords);
           feature.style = POINT_STYLE;
           feature.parentContainer = parentContainer;
-          feature.setData(d.id, d);
+          feature.setData(dataID, d);
         }
 
         this.syncFeatureClasses(feature);

--- a/modules/pixi/PixiLayerImproveOsm.js
+++ b/modules/pixi/PixiLayerImproveOsm.js
@@ -63,7 +63,7 @@ export class PixiLayerImproveOsm extends AbstractLayer {
     if (!service?.started) return;
 
     const parentContainer = this.scene.groups.get('qa');
-    const items = service.getItems(this.context.projection);  // note: context.projection !== pixi projection
+    const items = service.getData();
 
     for (const d of items) {
       const featureID = `${this.layerID}-${d.id}`;
@@ -105,7 +105,7 @@ export class PixiLayerImproveOsm extends AbstractLayer {
     const service = this.context.services.improveOSM;
     if (!this.enabled || !service?.started || zoom < MINZOOM) return;
 
-    service.loadIssues(this.context.projection);  // note: context.projection !== pixi projection
+    service.loadTiles();
     this.renderMarkers(frame, projection, zoom);
   }
 

--- a/modules/pixi/PixiLayerKartaPhotos.js
+++ b/modules/pixi/PixiLayerKartaPhotos.js
@@ -119,8 +119,8 @@ export class PixiLayerKartaPhotos extends AbstractLayer {
     if (!service?.started) return;
 
     const parentContainer = this.scene.groups.get('streetview');
-    const images = service.images(this.context.projection);
-    const sequences = service.sequences(this.context.projection);
+    const images = service.getImages();
+    const sequences = service.getSequences();
 
     const sequenceData = this.filterSequences(sequences);
     const photoData = this.filterImages(images);
@@ -191,7 +191,7 @@ export class PixiLayerKartaPhotos extends AbstractLayer {
     const service = this.context.services.kartaview;
     if (!this.enabled || !service?.started || zoom < MINZOOM) return;
 
-    service.loadImages(this.context.projection);  // note: context.projection !== pixi projection
+    service.loadTiles();
     this.renderMarkers(frame, projection, zoom);
   }
 

--- a/modules/pixi/PixiLayerKeepRight.js
+++ b/modules/pixi/PixiLayerKeepRight.js
@@ -63,7 +63,7 @@ export class PixiLayerKeepRight extends AbstractLayer {
     if (!service?.started) return;
 
     const parentContainer = this.scene.groups.get('qa');
-    const items = service.getItems(this.context.projection);  // note: context.projection !== pixi projection
+    const items = service.getData();
 
     for (const d of items) {
       const featureID = `${this.layerID}-${d.id}`;
@@ -100,7 +100,7 @@ export class PixiLayerKeepRight extends AbstractLayer {
     const service = this.context.services.keepRight;
     if (!this.enabled || !service?.started || zoom < MINZOOM) return;
 
-    service.loadIssues(this.context.projection);  // note: context.projection !== pixi projection
+    service.loadTiles();
     this.renderMarkers(frame, projection, zoom);
   }
 

--- a/modules/pixi/PixiLayerMapillaryFeatures.js
+++ b/modules/pixi/PixiLayerMapillaryFeatures.js
@@ -84,7 +84,7 @@ export class PixiLayerMapillaryFeatures extends AbstractLayer {
 
     const parentContainer = this.scene.groups.get('points');
 
-    let items = service.mapFeatures(this.context.projection);
+    let items = service.getData('points');
     items = this.filterDetections(items);
 
     for (const d of items) {
@@ -123,7 +123,7 @@ export class PixiLayerMapillaryFeatures extends AbstractLayer {
     const service = this.context.services.mapillary;
 
     if (this.enabled && service?.started && zoom >= MINZOOM) {
-      service.loadMapFeatures(this.context.projection);  // note: context.projection !== pixi projection
+      service.loadTiles('points');
       service.showFeatureDetections(true);
       this.renderMarkers(frame, projection, zoom);
 

--- a/modules/pixi/PixiLayerMapillaryPhotos.js
+++ b/modules/pixi/PixiLayerMapillaryPhotos.js
@@ -135,8 +135,8 @@ export class PixiLayerMapillaryPhotos extends AbstractLayer {
     // const showViewfields = (zoom >= MINVIEWFIELDZOOM);
 
     const parentContainer = this.scene.groups.get('streetview');
-    const sequences = service.sequences(this.context.projection);
-    const images = service.images(this.context.projection);
+    const sequences = service.getSequences();
+    const images = service.getData('images');
 
     const sequenceData = this.filterSequences(sequences);
     const photoData = this.filterImages(images);
@@ -208,7 +208,7 @@ export class PixiLayerMapillaryPhotos extends AbstractLayer {
     const service = this.context.services.mapillary;
     if (!this.enabled || !service?.started || zoom < MINZOOM) return;
 
-    service.loadImages(this.context.projection);  // note: context.projection !== pixi projection
+    service.loadTiles('images');
     this.renderMarkers(frame, projection, zoom);
   }
 

--- a/modules/pixi/PixiLayerMapillarySigns.js
+++ b/modules/pixi/PixiLayerMapillarySigns.js
@@ -84,7 +84,7 @@ export class PixiLayerMapillarySigns extends AbstractLayer {
 
     const parentContainer = this.scene.groups.get('points');
 
-    let items = service.signs(this.context.projection);
+    let items = service.getData('signs');
     items = this.filterDetections(items);
 
     for (const d of items) {
@@ -124,7 +124,7 @@ export class PixiLayerMapillarySigns extends AbstractLayer {
     const service = this.context.services.mapillary;
 
     if (this.enabled && service?.started && zoom >= MINZOOM) {
-      service.loadSigns(this.context.projection);  // note: context.projection !== pixi projection
+      service.loadTiles('signs');
       service.showSignDetections(true);
       this.renderMarkers(frame, projection, zoom);
 

--- a/modules/pixi/PixiLayerOsm.js
+++ b/modules/pixi/PixiLayerOsm.js
@@ -326,7 +326,7 @@ export class PixiLayerOsm extends AbstractLayer {
           style.labelTint = style.fill.color ?? style.stroke.color ?? 0xeeeeee;
           feature.style = style;
 
-          const label = l10n.displayPOIName(entity);
+          const label = l10n.displayPOIName(entity.tags);
           feature.label = label;
 
           // POI = "Point of Interest" -and- "Pole of Inaccessability"
@@ -490,7 +490,7 @@ export class PixiLayerOsm extends AbstractLayer {
             }
             feature.style = style;
 
-            feature.label = l10n.displayName(entity);
+            feature.label = l10n.displayName(entity.tags);
           }
 
           feature.update(projection, zoom);
@@ -616,7 +616,7 @@ export class PixiLayerOsm extends AbstractLayer {
         }
 
         feature.style = markerStyle;
-        feature.label = l10n.displayName(node);
+        feature.label = l10n.displayName(node.tags);
       }
 
       feature.update(projection, zoom);
@@ -701,7 +701,7 @@ export class PixiLayerOsm extends AbstractLayer {
         }
 
         feature.style = markerStyle;
-        feature.label = l10n.displayName(node);
+        feature.label = l10n.displayName(node.tags);
       }
 
       feature.update(projection, zoom);

--- a/modules/pixi/PixiLayerOsm.js
+++ b/modules/pixi/PixiLayerOsm.js
@@ -268,16 +268,16 @@ export class PixiLayerOsm extends AbstractLayer {
 
 
     for (const [entityID, entity] of entities) {
-      const entityVersion = (entity.v || 0);
+      const version = entity.v || 0;
 
       // Cache GeoJSON resolution, as we expect the rewind and asGeoJSON calls to be kinda slow.
       let geojson = this._resolved.get(entityID);
-      if (geojson?.v !== entityVersion) {  // bust cache if the entity has a new verison
+      if (geojson?.v !== version) {  // bust cache if the entity has a new verison
         geojson = null;
       }
       if (!geojson) {
         geojson = geojsonRewind(entity.asGeoJSON(graph), true);
-        geojson.v = entityVersion;
+        geojson.v = version;
         this._resolved.set(entityID, geojson);
       }
 
@@ -301,8 +301,8 @@ export class PixiLayerOsm extends AbstractLayer {
         }
 
         // If data has changed.. Replace data and parent-child links.
-        if (feature.v !== entityVersion) {
-          feature.v = entityVersion;
+        if (feature.v !== version) {
+          feature.v = version;
           feature.geometry.setCoords(coords);
           const area = feature.geometry.origExtent.area();   // estimate area from extent for speed
           feature.container.zIndex = -area;      // sort by area descending (small things above big things)
@@ -355,8 +355,8 @@ export class PixiLayerOsm extends AbstractLayer {
             poiFeature.parentContainer = pointsContainer;
           }
 
-          if (poiFeature.v !== entityVersion) {
-            poiFeature.v = entityVersion;
+          if (poiFeature.v !== version) {
+            poiFeature.v = version;
             poiFeature.geometry.setCoords(feature.geometry.origPoi);  // pole of inaccessability
             poiFeature.setData(entityID, entity);
           }
@@ -405,19 +405,19 @@ export class PixiLayerOsm extends AbstractLayer {
     const lineContainer = this.lineContainer;
 
     for (const [entityID, entity] of entities) {
-      const entityVersion = (entity.v || 0);
       const layer = (typeof entity.layer === 'function') ? entity.layer() : 0;
       const levelContainer = _getLevelContainer(layer.toString());
       const zindex = getzIndex(entity.tags);
+      const version = entity.v || 0;
 
       // Cache GeoJSON resolution, as we expect the asGeoJSON call to be kinda slow.
       let geojson = this._resolved.get(entityID);
-      if (geojson?.v !== entityVersion) {  // bust cache if the entity has a new verison
+      if (geojson?.v !== version) {  // bust cache if the entity has a new verison
         geojson = null;
       }
       if (!geojson) {
         geojson = entity.asGeoJSON(graph);
-        geojson.v = entityVersion;
+        geojson.v = version;
         if (geojson.type === 'LineString' && entity.tags.oneway === '-1') {
           geojson.coordinates.reverse();
         }
@@ -446,8 +446,8 @@ export class PixiLayerOsm extends AbstractLayer {
           }
 
           // If data has changed.. Replace data and parent-child links.
-          if (feature.v !== entityVersion) {
-            feature.v = entityVersion;
+          if (feature.v !== version) {
+            feature.v = version;
             feature.geometry.setCoords(coords);
             feature.parentContainer = levelContainer;    // Change layer stacking if necessary
             feature.container.zIndex = zindex;
@@ -557,6 +557,7 @@ export class PixiLayerOsm extends AbstractLayer {
       if (!parentContainer) continue;   // this vertex isn't important enough to render
 
       const featureID = `${this.layerID}-${nodeID}`;
+      const version = node.v || 0;
       let feature = this.features.get(featureID);
 
       // If feature existed before as a different type, recreate it.
@@ -570,9 +571,8 @@ export class PixiLayerOsm extends AbstractLayer {
       }
 
       // If data has changed, replace it.
-      const entityVersion = (node.v || 0);
-      if (feature.v !== entityVersion) {
-        feature.v = entityVersion;
+      if (feature.v !== version) {
+        feature.v = version;
         feature.geometry.setCoords(node.loc);
         feature.setData(nodeID, node);
       }
@@ -641,8 +641,8 @@ export class PixiLayerOsm extends AbstractLayer {
     const pointsContainer = this.scene.groups.get('points');
 
     for (const [nodeID, node] of entities) {
-      const entityVersion = (node.v || 0);
       const featureID = `${this.layerID}-${nodeID}`;
+      const version = node.v || 0;
       let feature = this.features.get(featureID);
 
       // If feature existed before as a different type, recreate it.
@@ -657,8 +657,8 @@ export class PixiLayerOsm extends AbstractLayer {
       }
 
       // If data has changed, replace it.
-      if (feature.v !== entityVersion) {
-        feature.v = entityVersion;
+      if (feature.v !== version) {
+        feature.v = version;
         feature.geometry.setCoords(node.loc);
         feature.setData(nodeID, node);
       }

--- a/modules/pixi/PixiLayerOsmose.js
+++ b/modules/pixi/PixiLayerOsmose.js
@@ -63,7 +63,7 @@ export class PixiLayerOsmose extends AbstractLayer {
     if (!service?.started) return;
 
     const parentContainer = this.scene.groups.get('qa');
-    const items = service.getItems(this.context.projection);
+    const items = service.getData();
 
     for (const d of items) {
       const featureID = `${this.layerID}-${d.id}`;
@@ -105,7 +105,7 @@ export class PixiLayerOsmose extends AbstractLayer {
     const service = this.context.services.osmose;
     if (!this.enabled || !service?.started || zoom < MINZOOM) return;
 
-    service.loadIssues(this.context.projection);  // note: context.projection !== pixi projection
+    service.loadTiles();
     this.renderMarkers(frame, projection, zoom);
   }
 

--- a/modules/pixi/PixiLayerRapid.js
+++ b/modules/pixi/PixiLayerRapid.js
@@ -380,7 +380,7 @@ export class PixiLayerRapid extends AbstractLayer {
             // fill: { width: 2, color: color, alpha: 1, pattern: 'stripe' }
           };
           feature.style = style;
-          feature.label = l10n.displayName(entity);
+          feature.label = l10n.displayName(entity.tags);
           feature.update(projection, zoom);
         }
 
@@ -425,7 +425,7 @@ export class PixiLayerRapid extends AbstractLayer {
         };
         style.lineMarkerName = entity.isOneWay() ? 'oneway' : '';
         feature.style = style;
-        feature.label = l10n.displayName(entity);
+        feature.label = l10n.displayName(entity.tags);
         feature.update(projection, zoom);
       }
 
@@ -469,7 +469,7 @@ export class PixiLayerRapid extends AbstractLayer {
 
       if (feature.dirty) {
         feature.style = pointStyle;
-        feature.label = l10n.displayName(entity);
+        feature.label = l10n.displayName(entity.tags);
         // experiment: label addresses
         const housenumber = entity.tags['addr:housenumber'];
         if (!feature.label && housenumber) {
@@ -499,7 +499,7 @@ export class PixiLayerRapid extends AbstractLayer {
 
       if (feature.dirty) {
         feature.style = vertexStyle;
-        feature.label = l10n.displayName(entity);
+        feature.label = l10n.displayName(entity.tags);
         // experiment: label addresses
         const housenumber = entity.tags['addr:housenumber'];
         if (!feature.label && housenumber) {

--- a/modules/pixi/PixiLayerRapid.js
+++ b/modules/pixi/PixiLayerRapid.js
@@ -252,15 +252,14 @@ export class PixiLayerRapid extends AbstractLayer {
 
     // Gather data
     let data = { points: [], vertices: new Set(), lines: [], polygons: [] };
-    // let data = { polygons: [], lines: [], points: [], vertices: new Set() };
 
     /* Facebook AI/ML */
     if (dataset.service === 'mapwithai') {
       if (zoom >= 15) { // avoid firing off too many API requests
-        service.loadTiles(datasetID, context.projection);  // fetch more
+        service.loadTiles(datasetID);  // fetch more
       }
 
-      const entities = service.intersects(datasetID, context.systems.map.extent())
+      const entities = service.getData(datasetID)
         .filter(d => d.type === 'way' && !isAccepted(d));  // see this._onRestore()
 
       // fb_ai service gives us roads and buildings together,
@@ -283,10 +282,10 @@ export class PixiLayerRapid extends AbstractLayer {
     /* ESRI ArcGIS */
     } else if (dataset.service === 'esri') {
       if (zoom >= 14) { // avoid firing off too many API requests
-        service.loadTiles(datasetID, context.projection);  // fetch more
+        service.loadTiles(datasetID);  // fetch more
       }
 
-      const entities = service.intersects(datasetID, context.systems.map.extent());
+      const entities = service.getData(datasetID);
 
       for (const entity of entities) {
         if (isAccepted(entity)) continue;   // skip features already accepted, see this._onRestore()

--- a/modules/pixi/PixiLayerStreetsidePhotos.js
+++ b/modules/pixi/PixiLayerStreetsidePhotos.js
@@ -119,8 +119,8 @@ export class PixiLayerStreetsidePhotos extends AbstractLayer {
     if (!service?.started) return;
 
     const parentContainer = this.scene.groups.get('streetview');
-    const images = service.bubbles(this.context.projection);
-    const sequences = service.sequences(this.context.projection);
+    const images = service.getImages();
+    const sequences = service.getSequences();
 
     const sequenceData = this.filterSequences(sequences);
     const photoData = this.filterImages(images);
@@ -192,7 +192,7 @@ export class PixiLayerStreetsidePhotos extends AbstractLayer {
     const service = this.context.services.streetside;
     if (!this.enabled || !service?.started || zoom < MINZOOM) return;
 
-    service.loadBubbles(this.context.projection);  // note: context.projection !== pixi projection
+    service.loadTiles();
     this.renderMarkers(frame, projection, zoom);
   }
 

--- a/modules/pixi/PixiScene.js
+++ b/modules/pixi/PixiScene.js
@@ -31,7 +31,7 @@ function asSet(vals) {
  * The "scene" maintains useful collections of Features.
  *
  * Features are organized into thematic Layers that can be enabled or disabled if needed.
- * Each Layer is responsible for managing its own data and Featuers.
+ * Each Layer is responsible for managing its own data and Features.
  * Features must be added to an appropriate group parent container.
  *
  * Notes on identifiers:

--- a/modules/services/EsriService.js
+++ b/modules/services/EsriService.js
@@ -81,26 +81,27 @@ export class EsriService extends AbstractSystem {
   }
 
 
-
-  graph(datasetID)  {
-    const ds = this._datasets[datasetID];
-    return ds?.graph;
-  }
-
-
-  intersects(datasetID, extent) {
+  /**
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @param   {string}  datasetID - datasetID to get data for
+   * @return  {Array}   Array of data (OSM Entities)
+   */
+  getData(datasetID) {
     const ds = this._datasets[datasetID];
     if (!ds || !ds.tree || !ds.graph) return [];
+
+    const extent = this.context.systems.map.extent();
     return ds.tree.intersects(extent, ds.graph);
   }
 
 
-  toggle(val) {
-    this._off = !val;
-  }
-
-
-  loadTiles(datasetID, projection) {
+  /**
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
+   * @param   {string}  datasetID - datasetID to load tiles for
+   */
+  loadTiles(datasetID) {
     if (this._off) return;
 
     // `loadDatasetsAsync` and `loadLayerAsync` are asynchronous,
@@ -110,6 +111,7 @@ export class EsriService extends AbstractSystem {
 
     const cache = ds.cache;
     const locationSystem = this.context.systems.locations;
+    const projection = this.context.projection;
     const tiles = this._tiler.getTiles(projection).tiles;
 
     // abort inflight requests that are no longer needed
@@ -134,6 +136,17 @@ export class EsriService extends AbstractSystem {
 
       this._loadTilePage(ds, tile, 0);
     }
+  }
+
+
+  graph(datasetID)  {
+    const ds = this._datasets[datasetID];
+    return ds?.graph;
+  }
+
+
+  toggle(val) {
+    this._off = !val;
   }
 
 

--- a/modules/services/ImproveOsmService.js
+++ b/modules/services/ImproveOsmService.js
@@ -99,10 +99,21 @@ export class ImproveOsmService extends AbstractSystem {
 
 
   /**
-   * loadIssues
-   * @param  projection
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @return  {Array}  Array of data
    */
-  loadIssues(projection) {
+  getData() {
+    const extent = this.context.systems.map.extent();
+    return this._cache.rtree.search(extent.bbox()).map(d => d.data);
+  }
+
+
+  /**
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
+   */
+  loadTiles() {
     const options = {
       client: 'Rapid',
       status: 'OPEN',
@@ -111,7 +122,7 @@ export class ImproveOsmService extends AbstractSystem {
 
     // determine the needed tiles to cover the view
     const context = this.context;
-    const tiles = this._tiler.getTiles(projection).tiles;
+    const tiles = this._tiler.getTiles(context.projection).tiles;
 
     // abort inflight requests that are no longer needed
     this._abortUnwantedRequests(this._cache, tiles);
@@ -406,22 +417,6 @@ export class ImproveOsmService extends AbstractSystem {
           if (callback) callback(e.message);
         });
     }
-  }
-
-
-  /**
-   * getItems
-   * Get all cached QAItems covering the viewport
-   * @param   projection
-   * @return  Array
-   */
-  getItems(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const bbox = new Extent(projection.invert(min), projection.invert(max)).bbox();
-
-    return this._cache.rtree.search(bbox).map(d => d.data);
   }
 
 

--- a/modules/services/KartaviewService.js
+++ b/modules/services/KartaviewService.js
@@ -1,5 +1,5 @@
 import { zoom as d3_zoom, zoomIdentity as d3_zoomIdentity } from 'd3-zoom';
-import { Extent, Tiler, geoScaleToZoom } from '@rapid-sdk/math';
+import { Tiler, geoScaleToZoom } from '@rapid-sdk/math';
 import { utilArrayUnion, utilQsString } from '@rapid-sdk/util';
 import RBush from 'rbush';
 
@@ -154,36 +154,30 @@ export class KartaviewService extends AbstractSystem {
 
 
   /**
-   * images
-   * Returns an Array of already-loaded images within the viewport
-   * @param  {Projection}  Projection that defines the current map view
-   * @return {Array}
+   * getImages
+   * Get already loaded image data that appears in the current map view
+   * @return  {Array}  Array of image data
    */
-  images(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const box = new Extent(projection.invert(min), projection.invert(max)).bbox();
-    return this._cache.rtree.search(box).map(d => d.data);
+  getImages() {
+    const extent = this.context.systems.map.extent();
+    return this._cache.rtree.search(extent.bbox()).map(d => d.data);
   }
 
 
   /**
-   * sequences
-   * Returns an Array of already-loaded sequences within the viewport
-   * @param  {Projection}  Projection that defines the current map view
-   * @return {Array}
+   * getSequences
+   * Get already loaded sequence data that appears in the current map view
+   * @return  {Array}  Array of sequence data
    */
-  sequences(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const bbox = new Extent(projection.invert(min), projection.invert(max)).bbox();
+  getSequences() {
+    const extent = this.context.systems.map.extent();
     let sequenceIDs = new Set();
 
     // Gather sequences for images in viewport
-    for (const box of this._cache.rtree.search(bbox)) {
-      if (box.data.sequenceID) sequenceIDs.add(box.data.sequenceID);
+    for (const box of this._cache.rtree.search(extent.bbox())) {
+      if (box.data.sequenceID) {
+        sequenceIDs.add(box.data.sequenceID);
+      }
     }
 
     // Make GeoJSON LineStrings from those sequences..
@@ -209,12 +203,13 @@ export class KartaviewService extends AbstractSystem {
 
 
   /**
-   * loadImages
-   * Loads image data for the given viewport
-   * @param  {Projection}  Projection that defines the current map view
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
    */
-  loadImages(projection) {
+  loadTiles() {
+    const projection = this.context.projection;
     const currZoom = Math.floor(geoScaleToZoom(projection.scale()));
+
     // Determine the needed tiles to cover the view
     const needTiles = this._tiler.getTiles(projection).tiles;
 

--- a/modules/services/KeepRightService.js
+++ b/modules/services/KeepRightService.js
@@ -115,17 +115,29 @@ export class KeepRightService extends AbstractSystem {
 
 
   /**
-   * loadIssues
-   * KeepRight API:  http://osm.mueschelsoft.de/keepright/interfacing.php
-   * @param  projection
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @return  {Array}  Array of data
    */
-  loadIssues(projection) {
+  getData() {
+    const extent = this.context.systems.map.extent();
+    return this._cache.rtree.search(extent.bbox()).map(d => d.data);
+  }
+
+
+  /**
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
+   * KeepRight API:  http://osm.mueschelsoft.de/keepright/interfacing.php
+   */
+  loadTiles() {
     const options = {
       format: 'geojson',
       ch: KR_RULES
     };
 
     // determine the needed tiles to cover the view
+    const projection = this.context.projection;
     const tiles = this._tiler.getTiles(projection).tiles;
 
     // abort inflight requests that are no longer needed
@@ -294,22 +306,6 @@ export class KeepRightService extends AbstractSystem {
 
         if (callback) callback(null, d);
       });
-  }
-
-
-  /**
-   * getItems
-   * Get all cached QAItems covering the viewport
-   * @param   projection
-   * @return  Array
-   */
-  getItems(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const bbox = new Extent(projection.invert(min), projection.invert(max)).bbox();
-
-    return this._cache.rtree.search(bbox).map(d => d.data);
   }
 
 

--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -90,34 +90,27 @@ export class MapWithAIService extends AbstractSystem {
   }
 
 
-
-  graph(datasetID) {
-    const ds = this._datasets[datasetID];
-    return ds?.graph;
-  }
-
-
-  intersects(datasetID, extent) {
+  /**
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @param   {string}  datasetID - datasetID to get data for
+   * @return  {Array}   Array of data (OSM Entities)
+   */
+  getData(datasetID) {
     const ds = this._datasets[datasetID];
     if (!ds || !ds.tree || !ds.graph) return [];
+
+    const extent = this.context.systems.map.extent();
     return ds.tree.intersects(extent, ds.graph);
   }
 
 
-  merge(datasetID, entities) {
-    const ds = this._datasets[datasetID];
-    if (!ds || !ds.tree || !ds.graph) return;
-    ds.graph.rebase(entities, [ds.graph], false);
-    ds.tree.rebase(entities, false);
-  }
-
-
-  toggle(val) {
-    this._off = !val;
-  }
-
-
-  loadTiles(datasetID, projection) {
+  /**
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
+   * @param   {string}  datasetID - datasetID to load tiles for
+   */
+  loadTiles(datasetID) {
     if (this._off) return;
 
     let ds = this._datasets[datasetID];
@@ -136,6 +129,7 @@ export class MapWithAIService extends AbstractSystem {
     }
 
     const locationSystem = this.context.systems.locations;
+    const projection = this.context.projection;
     const tiles = this._tiler.getTiles(projection).tiles;
 
     // abort inflight requests that are no longer needed
@@ -182,6 +176,25 @@ export class MapWithAIService extends AbstractSystem {
 
       cache.inflight[tile.id] = controller;
     }
+  }
+
+
+  graph(datasetID) {
+    const ds = this._datasets[datasetID];
+    return ds?.graph;
+  }
+
+
+  merge(datasetID, entities) {
+    const ds = this._datasets[datasetID];
+    if (!ds || !ds.tree || !ds.graph) return;
+    ds.graph.rebase(entities, [ds.graph], false);
+    ds.tree.rebase(entities, false);
+  }
+
+
+  toggle(val) {
+    this._off = !val;
   }
 
 

--- a/modules/services/MapillaryService.js
+++ b/modules/services/MapillaryService.js
@@ -1,5 +1,5 @@
 import { select as d3_select } from 'd3-selection';
-import { Extent, Tiler } from '@rapid-sdk/math';
+import { Tiler } from '@rapid-sdk/math';
 import { VectorTile } from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 import RBush from 'rbush';
@@ -10,13 +10,13 @@ import { utilFetchResponse } from '../util';
 const accessToken = 'MLY|3376030635833192|f13ab0bdf6b2f7b99e0d8bd5868e1d88';
 const apiUrl = 'https://graph.mapillary.com/';
 const baseTileUrl = 'https://tiles.mapillary.com/maps/vtp';
+const imageTileUrl = `${baseTileUrl}/mly1_public/2/{z}/{x}/{y}?access_token=${accessToken}`;
 const mapFeatureTileUrl = `${baseTileUrl}/mly_map_feature_point/2/{z}/{x}/{y}?access_token=${accessToken}`;
-const tileUrl = `${baseTileUrl}/mly1_public/2/{z}/{x}/{y}?access_token=${accessToken}`;
 const trafficSignTileUrl = `${baseTileUrl}/mly_map_feature_traffic_sign/2/{z}/{x}/{y}?access_token=${accessToken}`;
 
 const viewercss = 'mapillary-js/mapillary.css';
 const viewerjs = 'mapillary-js/mapillary.js';
-const minZoom = 14;
+const TILEZOOM = 14;
 
 
 /**
@@ -48,7 +48,7 @@ export class MapillaryService extends AbstractSystem {
     this._mlyShowSignDetections = false;
     this._mlyViewer = null;
     this._mlyViewerFilter = ['all'];
-    this._tiler = new Tiler().skipNullIsland(true);
+    this._tiler = new Tiler().zoomRange(TILEZOOM).skipNullIsland(true);
   }
 
 
@@ -139,10 +139,10 @@ export class MapillaryService extends AbstractSystem {
 
     this._mlyCache = {
       images: { rtree: new RBush(), forImageID: {} },
-      image_detections: { forImageID: {} },
-      signs: { rtree: new RBush() },
+      signs:  { rtree: new RBush() },
       points: { rtree: new RBush() },
       sequences: new Map(),    // Map(sequenceID -> Array of LineStrings)
+      image_detections: { forImageID: {} },
       requests: { loaded: {}, inflight: {} }
     };
 
@@ -153,62 +153,30 @@ export class MapillaryService extends AbstractSystem {
 
 
   /**
-   * images
-   * Returns an Array of already-loaded images within the viewport
-   * @param  {Projection}  Projection that defines the current map view
-   * @return {Array}
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @param   {string}  datasetID - one of 'images', 'signs', or 'points'
+   * @return  {Array}
    */
-  images(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const box = new Extent(projection.invert(min), projection.invert(max)).bbox();
-    return this._mlyCache.images.rtree.search(box).map(d => d.data);
+  getData(datasetID) {
+    if (!['images', 'signs', 'points'].includes(datasetID)) return [];
+
+    const extent = this.context.systems.map.extent();
+    const cache = this._mlyCache[datasetID];
+    return cache.rtree.search(extent.bbox()).map(d => d.data);
   }
 
-  /**
-   * signs
-   * Returns an Array of already-loaded traffic signs within the viewport
-   * @param  {Projection}  Projection that defines the current map view
-   * @return {Array}
-   */
-  signs(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const box = new Extent(projection.invert(min), projection.invert(max)).bbox();
-    return this._mlyCache.signs.rtree.search(box).map(d => d.data);
-  }
 
   /**
-   * mapFeatures
-   * Returns an Array of already-loaded detected point features within the viewport
-   * @param  {Projection}  Projection that defines the current map view
-   * @return {Array}
+   * getSequences
+   * Get already loaded sequence data that appears in the current map view
+   * @return  {Array}
    */
-  mapFeatures(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const box = new Extent(projection.invert(min), projection.invert(max)).bbox();
-    return this._mlyCache.points.rtree.search(box).map(d => d.data);
-  }
-
-  /**
-   * sequences
-   * Returns an Array of already-loaded sequences within the viewport
-   * @param  {Projection}  Projection that defines the current map view
-   * @return {Array}
-   */
-  sequences(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const bbox = new Extent(projection.invert(min), projection.invert(max)).bbox();
+  getSequences() {
+    const extent = this.context.systems.map.extent();
     let result = new Map();  // Map(sequenceID -> Array of LineStrings)
 
-    // Gather sequences for images in viewport
-    for (const box of this._mlyCache.images.rtree.search(bbox)) {
+    for (const box of this._mlyCache.images.rtree.search(extent.bbox())) {
       const sequenceID = box.data.sequenceID;
       if (!sequenceID) continue;  // no sequence for this image
       const sequence = this._mlyCache.sequences.get(sequenceID);
@@ -218,38 +186,27 @@ export class MapillaryService extends AbstractSystem {
         result.set(sequenceID, sequence);
       }
     }
+
     return [...result.values()];
   }
 
 
   /**
-   * loadImages
-   * Loads image data for the given viewport
-   * @param  {Projection}  Projection that defines the current map view
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
+   * @param   {string}  datasetID - one of 'images', 'signs', or 'points'
    */
-  loadImages(projection) {
-    this._loadTiles('images', tileUrl, 14, projection);
+  loadTiles(datasetID) {
+    if (!['images', 'signs', 'points'].includes(datasetID)) return;
+
+    // determine the needed tiles to cover the view
+    const projection = this.context.projection;
+    const tiles = this._tiler.getTiles(projection).tiles;
+    for (const tile of tiles) {
+      this._loadTile(datasetID, tile);
+    }
   }
 
-
-  /**
-   * loadSigns
-   * Loads traffic sign data for the given viewport
-   * @param  {Projection}  Projection that defines the current map view
-   */
-  loadSigns(projection) {
-    this._loadTiles('signs', trafficSignTileUrl, 14, projection);
-  }
-
-
-  /**
-   * loadMapFeatures
-   * Loads detected point feature data for the given viewport
-   * @param  {Projection}  Projection that defines the current map view
-   */
-  loadMapFeatures(projection) {
-    this._loadTiles('points', mapFeatureTileUrl, 14, projection);
-  }
 
   /**
    * resetTags
@@ -260,6 +217,7 @@ export class MapillaryService extends AbstractSystem {
       this._mlyViewer.getComponent('tag').removeAll();
     }
   }
+
 
   /**
    * showFeatureDetections
@@ -531,30 +489,29 @@ export class MapillaryService extends AbstractSystem {
   }
 
 
-  // Load all data for the specified type from Mapillary vector tiles
-  _loadTiles(which, url, maxZoom, projection) {
-    // determine the needed tiles to cover the view
-    const tiles = this._tiler.zoomRange(minZoom, maxZoom).getTiles(projection).tiles;
-    for (const tile of tiles) {
-      this._loadTile(which, url, tile);
-    }
-  }
-
-
   // Load all data for the specified type from one vector tile
-  _loadTile(which, url, tile) {
+  _loadTile(datasetID, tile) {
+    if (!['images', 'signs', 'points'].includes(datasetID)) return;
+
     const cache = this._mlyCache.requests;
-    const tileID = `${tile.id}-${which}`;
+    const tileID = `${tile.id}-${datasetID}`;
     if (cache.loaded[tileID] || cache.inflight[tileID]) return;
 
     const controller = new AbortController();
     cache.inflight[tileID] = controller;
-    const requestUrl = url
+
+    let url = {
+      images: imageTileUrl,
+      signs: trafficSignTileUrl,
+      points: mapFeatureTileUrl
+    }[datasetID];
+
+    url = url
       .replace('{x}', tile.xyz[0])
       .replace('{y}', tile.xyz[1])
       .replace('{z}', tile.xyz[2]);
 
-    fetch(requestUrl, { signal: controller.signal })
+    fetch(url, { signal: controller.signal })
       .then(utilFetchResponse)
       .then(buffer => {
         cache.loaded[tileID] = true;
@@ -565,11 +522,11 @@ export class MapillaryService extends AbstractSystem {
         this._loadTileDataToCache(buffer, tile);
 
         this.context.deferredRedraw();
-        if (which === 'images') {
+        if (datasetID === 'images') {
           this.emit('loadedImages');
-        } else if (which === 'signs') {
+        } else if (datasetID === 'signs') {
           this.emit('loadedSigns');
-        } else if (which === 'points') {
+        } else if (datasetID === 'points') {
           this.emit('loadedMapFeatures');
         }
       })

--- a/modules/services/OsmWikibaseService.js
+++ b/modules/services/OsmWikibaseService.js
@@ -34,7 +34,6 @@ export class OsmWikibaseService extends AbstractSystem {
   }
 
 
-
   /**
    * initAsync
    * Called after all core objects have been constructed.

--- a/modules/services/OsmoseService.js
+++ b/modules/services/OsmoseService.js
@@ -92,11 +92,23 @@ export class OsmoseService extends AbstractSystem {
 
 
   /**
-   * loadIssues
-   * @param  projection
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @return  {Array}  Array of data
    */
-  loadIssues(projection) {
+  getData() {
+    const extent = this.context.systems.map.extent();
+    return this._cache.rtree.search(extent.bbox()).map(d => d.data);
+  }
+
+
+  /**
+   * loadTiles
+   * Schedule any data requests needed to cover the current map view
+   */
+  loadTiles() {
     // determine the needed tiles to cover the view
+    const projection = this.context.projection;
     const tiles = this._tiler.getTiles(projection).tiles;
 
     // abort inflight requests that are no longer needed
@@ -253,22 +265,6 @@ export class OsmoseService extends AbstractSystem {
         delete this._cache.inflightPost[issue.id];
         if (callback) callback(err.message);
       });
-  }
-
-
-  /**
-   * getItems
-   * Get all cached QAItems covering the viewport
-   * @param   projection
-   * @return  Array of data
-   */
-  getItems(projection) {
-    const viewport = projection.dimensions();
-    const min = [viewport[0][0], viewport[1][1]];
-    const max = [viewport[1][0], viewport[0][1]];
-    const bbox = new Extent(projection.invert(min), projection.invert(max)).bbox();
-
-    return this._cache.rtree.search(bbox).map(d => d.data);
   }
 
 

--- a/modules/services/VectorTileService.js
+++ b/modules/services/VectorTileService.js
@@ -1,12 +1,12 @@
-import { Tiler } from '@rapid-sdk/math';
+import { Extent, Tiler, vecEqual } from '@rapid-sdk/math';
 import { utilHashcode } from '@rapid-sdk/util';
 import { VectorTile } from '@mapbox/vector-tile';
+import geojsonRewind from '@mapbox/geojson-rewind';
 import { PMTiles } from 'pmtiles';
-import deepEqual from 'fast-deep-equal';
-import turf_bboxClip from '@turf/bbox-clip';
 import stringify from 'fast-json-stable-stringify';
 import polygonClipping from 'polygon-clipping';
 import Protobuf from 'pbf';
+import RBush from 'rbush';
 
 import { AbstractSystem } from '../core/AbstractSystem';
 import { utilFetchResponse } from '../util';
@@ -14,6 +14,15 @@ import { utilFetchResponse } from '../util';
 
 /**
  * `VectorTileService`
+ * This service can connect to sources of vector tile data
+ *
+ * - Mapbox Vector Tiles (MVT) made available from a z/x/y tileserver
+ *     https://github.com/mapbox/vector-tile-spec
+ *     https://github.com/mapbox/vector-tile-js/tree/master
+ *
+ * - Protomaps .pmtiles single-file archive containing MVT
+ *    https://protomaps.com/docs/pmtiles
+ *    https://github.com/protomaps/PMTiles
  *
  * Events available:
  *   'loadedData'
@@ -28,8 +37,10 @@ export class VectorTileService extends AbstractSystem {
     super(context);
     this.id = 'vectortile';
 
-    this._cache = new Map();   // Map(sourceID -> source)
+    // Sources are identified by their URL template..
+    this._sources = new Map();   // Map(template -> source)
     this._tiler = new Tiler().tileSize(512).margin(1);
+    this._nextID = 0;
   }
 
 
@@ -60,56 +71,82 @@ export class VectorTileService extends AbstractSystem {
    * @return {Promise} Promise resolved when this component has completed resetting
    */
   resetAsync() {
-    for (const source of this._cache.values()) {
-      for (const controller of Object.values(source.inflight)) {
-        this._abortRequest(controller);
+    for (const source of this._sources.values()) {
+      for (const controller of source.inflight.values()) {
+        controller.abort();
       }
-    }
 
-    this._cache.clear();
+      // free memory
+      source.inflight.clear();
+      source.loaded.clear();
+      source.readyPromise = null;
+      for (const cache of source.zoomCache.values()) {
+        cache.features.clear();
+        cache.boxes.clear();
+        cache.toMerge.clear();
+        cache.didMerge.clear();
+        cache.rbush.clear();
+      }
+      source.zoomCache.clear();
+    }
+    this._sources.clear();
 
     return Promise.resolve();
   }
 
 
   /**
-   * data (maybe should be "getData"?)
-   * @param  sourceID
-   * @param  projection
+   * getNextID
+   * Get a unique ID
+   * @return  {string}   Unique ID
    */
-  data(sourceID, projection) {
-    const source = this._cache.get(sourceID);
+  getNextID() {
+    return (this._nextID++).toString();
+  }
+
+
+  /**
+   * getData
+   * Get already loaded data that appears in the current map view
+   * @param   {string}  template - template to get data for
+   * @return  {Array}   Array of data
+   */
+  getData(template) {
+    const source = this._sources.get(template);
     if (!source) return [];
 
-    const tiles = this._tiler.getTiles(projection).tiles;
-    const seen = new Set();
-    let results = [];
+    const map = this.context.systems.map;
+    const extent = map.extent();
 
-    for (const tile of tiles) {
-      const features = source.loaded[tile.id] ?? [];
-      for (const feature of features) {
-        const hash = feature.__featurehash__;
-        if (seen.has(hash)) continue;
-        seen.add(hash);
+    // -1 because vector tiles are 512px, so they are offset by 1 zoom level
+    // from the main map zoom, which follows 256px and OSM convention.
+    const zoom = Math.round(map.zoom()) - 1;
 
-        // return a shallow copy, because the hash may change
-        // later if this feature gets merged with another
-        results.push(Object.assign({}, feature));  // shallow copy
+    // Because vector tiled data can be different at different zooms,
+    // the caches and indexes need to be setup "per-zoom".
+    // Look for a cache at the zoom we are at first, then try other zooms.
+    let cache;
+    for (let diff = 0; diff < 12; diff++) {
+      cache = source.zoomCache.get(zoom + diff);
+      if (cache) {
+        return cache.rbush.search(extent.bbox()).map(d => d.data);
+      }
+      cache = source.zoomCache.get(zoom - diff);
+      if (cache) {
+        return cache.rbush.search(extent.bbox()).map(d => d.data);
       }
     }
-
-    return results;
+    return [];
   }
 
 
   /**
    * loadTiles
-   * @param  sourceID
-   * @param  template
-   * @param  projection
+   * Schedule any data requests needed to cover the current map view
+   * @param   {string}  template - template to load tiles for
    */
-  loadTiles(sourceID, template, projection) {
-    this.addSourceAsync(sourceID, template)
+  loadTiles(template) {
+    this._getSourceAsync(template)
       .then(source => {
         const header = source.header;
         if (header) {  // pmtiles - set up allowable zoom range
@@ -119,58 +156,61 @@ export class VectorTileService extends AbstractSystem {
           }
         }
 
-        const tiles = this._tiler.getTiles(projection).tiles;
+        // Determine the needed tiles to cover the view
+        const projection = this.context.projection;
+        const needTiles = this._tiler.getTiles(projection).tiles;
 
-        // abort inflight requests that are no longer needed
-        for (const k of Object.keys(source.inflight)) {
-          const wanted = tiles.find(tile => tile.id === k);
-          if (!wanted) {
-            this._abortRequest(source.inflight[k]);
-            delete source.inflight[k];
+        // Abort inflight requests that are no longer needed
+        for (const [tileID, controller] of source.inflight) {
+          const needed = needTiles.find(tile => tile.id === tileID);
+          if (!needed) {
+            controller.abort();
           }
         }
 
-        for (const tile of tiles) {
-          this._loadTile(source, tile);
-        }
+        const fetches = needTiles.map(tile => this._loadTileAsync(source, tile));
+        return Promise.all(fetches)
+          .then(() => this._processMergeQueue(source));
       });
   }
 
 
   /**
-   * addSourceAsync
-   * Create a new cache to hold data for the given source
-   * @param   sourceID
-   * @param   template
+   * _getSourceAsync
+   * Create a new cache to hold data for the given template
+   * @param   {string}  template - A url template for fetching data (e.g. a z/x/y tileserver or .pmtiles)
    * @return  Promise resolved to the source object once it is ready to use
    */
-  addSourceAsync(sourceID, template) {
-    let source = this._cache.get(sourceID);
+  _getSourceAsync(template) {
+    if (!template) return Promise.reject(new Error('No template'));
+
+    let source = this._sources.get(template);
 
     if (!source) {  // create it
       const url = new URL(template);
       const hostname = url.hostname;
       const filename = url.pathname.split('/').at(-1);
-      let displayName = hostname;
 
       source = {
-        displayName: displayName,
-        template: template,
-        inflight: {},
-        loaded: {},
-        canMerge: {}
+        id:           utilHashcode(template).toString(),
+        displayName:  hostname,
+        template:     template,
+        inflight:     new Map(),   // Map(tileID -> AbortController)
+        loaded:       new Map(),   // Map(tileID -> Tile)
+        zoomCache:    new Map()    // Map(zoom -> Object zoomCache)
       };
 
-      this._cache.set(sourceID, source);
+      this._sources.set(template, source);
 
       // Special handling for PMTiles sources
-      // Create a PMTiles instance and fetch the header so we know more aobut the source.
+      // Create a PMTiles instance and fetch the header so we know more about the source.
       if (filename && /\.pmtiles$/.test(filename)) {
         source.displayName = filename;
         source.pmtiles = new PMTiles(template);
         source.readyPromise = source.pmtiles.getHeader()
           .then(header => source.header = header)
           .then(() => Promise.resolve(source));
+
       } else {
         source.readyPromise = Promise.resolve(source);
       }
@@ -181,147 +221,492 @@ export class VectorTileService extends AbstractSystem {
 
 
   /**
-   * _abortRequest
-   * Call this to abort any unfinished tile fetch request
-   * @param  controller  {AbortController}
+   * _getZoomCache
+   * Because vector tiled data can be different at different zooms,
+   * the caches and indexes need to be setup "per-zoom".
+   * This function will return the existing zoom cache, or create one if needed.
+   * @param   {string}  source
+   * @param   {number}  zoom
+   * @return  {Object}  the cache for the given zoom
    */
-  _abortRequest(controller) {
-    controller.abort();
+  _getZoomCache(source, zoom) {
+    let cache = source.zoomCache.get(zoom);
+
+    if (!cache) {
+      cache = {
+        features: new Map(),   // Map(featureID -> Object)
+        boxes:    new Map(),   // Map(featureID -> RBush box)
+        toMerge:  new Map(),   // Map(edgeID -> Map(prophash -> Set(featureIDs)))
+        didMerge: new Set(),   // Set(edgeID)
+        rbush:    new RBush()
+      };
+
+      source.zoomCache.set(zoom, cache);
+    }
+
+    return cache;
   }
 
 
   /**
-   * _loadTile
-   * @param  source
-   * @param  tile
+   * _loadTileAsync
+   * @param   source
+   * @param   tile
+   * @return  {Promise} returns the fetch promise
    */
-  _loadTile(source, tile) {
-    if (source.loaded[tile.id] || source.inflight[tile.id]) return;
+  _loadTileAsync(source, tile) {
+    const tileID = tile.id;
+    if (source.loaded.has(tileID) || source.inflight.has(tileID)) return;
 
     const controller = new AbortController();
-    source.inflight[tile.id] = controller;
+    source.inflight.set(tileID, controller);
 
+    const [x, y, z] = tile.xyz;
     let _fetch;
 
     if (source.pmtiles) {
       _fetch = source.pmtiles
-        .getZxy(tile.xyz[2], tile.xyz[0], tile.xyz[1], controller.signal)
-        .then(response => {
-          return response?.data;
-        });
+        .getZxy(z, x, y, controller.signal)
+        .then(response => response?.data);
 
     } else {
       const url = source.template
-        .replace('{x}', tile.xyz[0])
-        .replace('{y}', tile.xyz[1])
-        // TMS-flipped y coordinate
-        .replace(/\{[t-]y\}/, Math.pow(2, tile.xyz[2]) - tile.xyz[1] - 1)
-        .replace(/\{z(oom)?\}/, tile.xyz[2])
+        .replace('{x}', x)
+        .replace('{y}', y)
+        .replace(/\{[t-]y\}/, Math.pow(2, z) - y - 1)  // TMS-flipped y coordinate
+        .replace(/\{z(oom)?\}/, z)
         .replace(/\{switch:([^}]+)\}/, function(s, r) {
           const subdomains = r.split(',');
-          return subdomains[(tile.xyz[0] + tile.xyz[1]) % subdomains.length];
+          return subdomains[(x + y) % subdomains.length];
         });
 
       _fetch = fetch(url, { signal: controller.signal })
         .then(utilFetchResponse);
     }
 
-    _fetch
+    return _fetch
       .then(buffer => {
-        delete source.inflight[tile.id];
-        if (!buffer) {
-          throw new Error('No Data');
-        }
-
-        const z = tile.xyz[2];
-        if (!source.canMerge[z]) {
-          source.canMerge[z] = {};  // initialize mergeCache
-        }
-
-        source.loaded[tile.id] = this._vtToGeoJSON(buffer, tile, source.canMerge[z]);
-        this.context.deferredRedraw();
-        this.emit('loadedData');
+        source.loaded.set(tileID, tile);
+        this._parseTileBuffer(source, tile, buffer);
       })
       .catch(err => {
         if (err.name === 'AbortError') return;          // ok
         if (err instanceof Error) console.error(err);   // eslint-disable-line no-console
-        source.loaded[tile.id] = [];
-        delete source.inflight[tile.id];
+      })
+      .finally(() => {
+        source.inflight.delete(tileID);
       });
   }
 
 
   /**
-   * _vtToGeoJSON
-   * @param  buffer
+   * _parseTileBuffer
+   * @param  source
    * @param  tile
-   * @param  mergeCache
+   * @param  buffer
    */
-  _vtToGeoJSON(buffer, tile, mergeCache) {
-    const vectorTile = new VectorTile(new Protobuf(buffer));
-    let layerIDs = Object.keys(vectorTile.layers);
-    if (!Array.isArray(layerIDs)) layerIDs = [layerIDs];
+  _parseTileBuffer(source, tile, buffer) {
+    if (!buffer) return;  // 'no data' is ok
 
-    let features = [];
-    for (const layerID of layerIDs) {
-      const layer = vectorTile.layers[layerID];
-      if (!layer) continue;
+    // Get some info about this tile and its neighbors
+    const [x, y, z] = tile.xyz;
+    const tileID = tile.id;
+    const tileExtent = tile.wgs84Extent;
 
-      for (let i = 0; i < layer.length; i++) {
-        const feature = layer.feature(i).toGeoJSON(tile.xyz[0], tile.xyz[1], tile.xyz[2]);
-        const geometry = feature.geometry;
+    //       -y
+    //     +----+
+    //  -x |    | +x
+    //     +----+
+    //       +y
 
-        // Treat all Polygons as MultiPolygons
-        if (geometry.type === 'Polygon') {
-          geometry.type = 'MultiPolygon';
-          geometry.coordinates = [geometry.coordinates];
+    // Define tile edges (lower x,y,z - higher x,y,z)
+    const leftEdge = `${x-1},${y},${z}-${tileID}`;
+    const rightEdge = `${tileID}-${x+1},${y},${z}`;
+    const topEdge = `${x},${y-1},${z}-${tileID}`;
+    const bottomEdge = `${tileID}-${x},${y+1},${z}`;
+
+    const vt = new VectorTile(new Protobuf(buffer));
+    const cache = this._getZoomCache(source, z);
+
+    const newFeatures = [];
+    for (const [layerID, vtLayer] of Object.entries(vt.layers)) {
+      if (!vtLayer) continue;
+
+      // Determine extent of tile coordinates
+      const min = 0;
+      const max = vtLayer.extent;  // default 4096
+
+      // For each feature on the vector tile...
+      for (let i = 0; i < vtLayer.length; i++) {
+        const vtFeature = vtLayer.feature(i);
+        const [left, top, right, bottom] = vtFeature.bbox();
+
+        // This feature is wholly on a neighbor tile - it just spills onto this tile in the buffer..
+        if (left > max || top > max || right < min || bottom < min) continue;
+
+        // Force all properties to strings
+        for (const [k, v] of Object.entries(vtFeature.properties)) {
+          vtFeature.properties[k] = v.toString();
         }
 
-        // Does this feature clip to tile bounds?
-        // (there is probably a much more efficient way to determine this)
-        let isClipped = false;
-        if (geometry.type === 'MultiPolygon') {
-          const featureClip = turf_bboxClip(feature, tile.wgs84Extent.rectangle());
-          if (!deepEqual(feature.geometry, featureClip.geometry)) {
-            // feature = featureClip;
-            isClipped = true;
-          }
-          if (!feature.geometry.coordinates.length) continue;   // not actually on this tile
-          if (!feature.geometry.coordinates[0].length) continue;   // not actually on this tile
+        // When features have the same properties, we'll consider them mergeable.
+        const prophash = utilHashcode(stringify(vtFeature.properties)).toString();
+
+        // If the feature doesn't have an id, use the prophash as the id
+        if (!vtFeature.id) {
+          vtFeature.id = prophash;
         }
 
-        // Generate some unique IDs and add some metadata
-        const featurehash = utilHashcode(stringify(feature));
-        const propertyhash = utilHashcode(stringify(feature.properties || {}));
-        feature.__layerID__ = layerID.replace(/[^_a-zA-Z0-9\-]/g, '_');
-        feature.__featurehash__ = featurehash;
-        feature.__propertyhash__ = propertyhash;
-        feature.v = 0;
-        features.push(feature);
+        // Convert to GeoJSON
+        const orig = vtFeature.toGeoJSON(x, y, z);
 
-        // Clipped Polygons at same zoom with identical properties can get merged (polygon union)
-        if (isClipped && geometry.type === 'MultiPolygon') {
-          let merged = mergeCache[propertyhash];
-          if (merged?.length) {
-            const other = merged[0];
-            const v = other.v + 1;     // bump version
-            const coords = polygonClipping.union(feature.geometry.coordinates, other.geometry.coordinates);
-            if (!coords || !coords.length) continue;  // something failed in polygon union
+        // It's common for a vector tile to return 'Multi' GeoJSON features..
+        // e.g. All the roads together in one `MultiLineString`.
+        // For our purposes, we really want to work with them as single features..
+        for (const geojson of this._toSingleFeatures(orig)) {
+          const extent = this._calcExtent(geojson);
+          if (!isFinite(extent.min[0])) continue;  // invalid - no coordinates?
 
-            merged.push(feature);
-            for (const feat of merged) {    // all these merged features share...
-              feat.v = v;                           // save version, so they get redrawn
-              feat.geometry.coordinates = coords;   // same coords, so they get redrawn _properly_
-              feat.__featurehash__ = featurehash;   // same hash, so deduplication works
-            }
-          } else {
-            mergeCache[propertyhash] = [feature];
+          // Generate a unique id for this feature
+          const featureID = this.getNextID();
+          geojson.id = featureID;
+          geojson.__featurehash__ = featureID;  // legacy
+
+//// add a few extra props for debugging
+//geojson.properties['__featureID'] = featureID;
+//geojson.properties['__tileID'] = tile.id;
+//geojson.properties['__prophash'] = prophash;
+
+          // For Polygons only, determine if this feature clips to a tile edge.
+          // If so, we'll try to merge it with similar features on the neighboring tile
+          if (geojson.geometry.type === 'Polygon') {
+            if (extent.min[0] < tileExtent.min[0]) { this._queueMerge(cache, featureID, prophash, leftEdge); }
+            if (extent.max[0] > tileExtent.max[0]) { this._queueMerge(cache, featureID, prophash, rightEdge); }
+            if (extent.min[1] < tileExtent.min[1]) { this._queueMerge(cache, featureID, prophash, bottomEdge); }
+            if (extent.max[1] > tileExtent.max[1]) { this._queueMerge(cache, featureID, prophash, topEdge); }
           }
+
+          newFeatures.push({
+            id: featureID,
+            extent: extent,
+            layerID: layerID,
+            prophash: prophash,
+            geojson: geojsonRewind(geojson, true),
+            v: 0
+          });
         }
       }
     }
 
-    return features;
+    if (newFeatures.length) {
+      this._cacheFeatures(cache, newFeatures);
+      this.context.deferredRedraw();
+      this.emit('loadedData');
+    }
   }
 
+
+  /**
+   * _queueMerge
+   * Mark this data as eligible for merging across given tile edge
+   */
+  _queueMerge(cache, featureID, prophash, edgeID) {
+    if (cache.didMerge.has(edgeID)) return;  // we merged this edge already
+
+    let mergemap = cache.toMerge.get(edgeID);
+    if (!mergemap) {
+      mergemap = new Map();    // Map(prophash -> Set(featureIDs))
+      cache.toMerge.set(edgeID, mergemap);
+    }
+    let featureIDs = mergemap.get(prophash);
+    if (!featureIDs) {
+      featureIDs = new Set();
+      mergemap.set(prophash, featureIDs);
+    }
+    featureIDs.add(featureID);
+  }
+
+
+  /**
+   * _processMergeQueue
+   * Call this sometimes to merge polygons across tile edges
+   */
+  _processMergeQueue(source) {
+    for (const cache of source.zoomCache.values()) {
+      for (const [edgeID, mergemap] of cache.toMerge) {  // for each edge
+
+        // Are both tiles loaded?
+        const [lowID, highID] = edgeID.split('-');
+        const lowTile = source.loaded.get(lowID);
+        const highTile = source.loaded.get(highID);
+        if (!lowTile || !highTile) continue;
+
+        cache.didMerge.add(edgeID);
+
+        // All the features that share this prophash along this edge can be merged
+        for (const [prophash, featureIDs] of mergemap) {
+          this._mergePolygons(cache, prophash, featureIDs, lowTile, highTile);
+          mergemap.delete(prophash);  // done this prophash
+        }
+        cache.toMerge.delete(edgeID);
+      }
+    }
+  }
+
+
+  /**
+   * _cacheFeatures
+   * @param  {Object}  cache
+   * @param  {Array}  features
+   */
+  _cacheFeatures(cache, features) {
+    const boxes = [];
+    for (const feature of features) {
+      cache.features.set(feature.id, feature);  // cache feature
+
+      const box = feature.extent.bbox();
+      box.data = feature;
+      cache.boxes.set(feature.id, box);   // cache box
+      boxes.push(box);
+    }
+
+    cache.rbush.load(boxes);  // bulk load
+  }
+
+
+  /**
+   * _uncacheFeatureIDs
+   * @param  {Object}  cache
+   * @param  {Set}     featureIDs - Set(featureIDs)
+   */
+  _uncacheFeatureIDs(cache, featureIDs) {
+    for (const featureID of featureIDs) {
+      const box = cache.boxes.get(featureID);
+      if (box) {
+        cache.boxes.delete(featureID);  // uncache box
+        cache.rbush.remove(box);
+      }
+      cache.features.delete(featureID);  // uncache feature
+    }
+  }
+
+
+  /**
+   * _mergePolygons
+   * Merge the given features across the given edge (defined by lowTile/highTile)
+   * @param  {Object}  cache
+   * @param  {Set}     featureIDs   Set(featureIDs) to merge
+   * @param  {Tile}    lowTile
+   * @param  {Tile}    highTile
+   */
+  _mergePolygons(cache, prophash, featureIDs, lowTile, highTile) {
+    const features = Array.from(featureIDs).map(featureID => cache.features.get(featureID)).filter(Boolean);
+    if (!features.length) return;
+
+    // We have more edges to keep track of now..
+    // The tiles involved in this merge will be in one of these orientations:
+    //
+    //                          +------+
+    //  +-----+------+          | low  |
+    //  | low | high |    or    +------+
+    //  +-----+------+          | high |
+    //                          +------+
+    //
+    // Important to ignore the edge betwen low-high, as this is the one we are currently merging!
+    // Edges to ignore will either be "lowRight,highLeft" or "lowBottom,highTop"
+
+    // Define tile edges (lower x,y,z - higher x,y,z)
+    const [lx, ly, lz] = lowTile.xyz;
+    const [hx, hy, hz] = highTile.xyz;
+    const lowTileID = lowTile.id;
+    const highTileID = highTile.id;
+    const lowTileExtent = lowTile.wgs84Extent;
+    const highTileExtent = highTile.wgs84Extent;
+    const isVertical = (hy === ly + 1);
+    const isHorizontal = (hx === lx + 1);
+    const lowLeftEdge = `${lx-1},${ly},${lz}-${lowTileID}`;
+    const lowRightEdge = `${lowTileID}-${lx+1},${ly},${lz}`;
+    const lowTopEdge = `${lx},${ly-1},${lz}-${lowTileID}`;
+    const lowBottomEdge = `${lowTileID}-${lx},${ly+1},${lz}`;
+    const highLeftEdge = `${hx-1},${hy},${hz}-${highTileID}`;
+    const highRightEdge = `${highTileID}-${hx+1},${hy},${hz}`;
+    const highTopEdge = `${hx},${hy-1},${hz}-${highTileID}`;
+    const highBottomEdge = `${highTileID}-${hx},${hy+1},${hz}`;
+
+    // The merged feature(s) can copy some properties from the first one
+    const source = features[0];
+
+    this._uncacheFeatureIDs(cache, featureIDs);
+
+    // Union the coordinates together
+    const sourceCoords = features.map(feature => feature.geojson.geometry.coordinates);
+    const mergedCoords = polygonClipping.union(...sourceCoords);
+    if (!mergedCoords || !mergedCoords.length) {
+      throw new Error(`Failed to merge`);  // shouldn't happen
+    }
+
+    // `polygonClip.union` always returns a MultiPolygon
+    const merged = {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: mergedCoords
+      },
+      properties: Object.assign({}, source.geojson.properties)   // shallow copy
+    };
+
+    // Convert whatever we got into new polygons
+    const newFeatures = [];
+    for (const geojson of this._toSingleFeatures(merged)) {
+      const extent = this._calcExtent(geojson);
+      if (!isFinite(extent.min[0])) continue;  // invalid - no coordinates?
+
+      this._dedupePoints(geojson);  // remove coincident points caused by union operation
+
+      // Generate a unique id for this feature
+      const featureID = this.getNextID();
+      geojson.id = featureID;
+      geojson.__featurehash__ = featureID;  // legacy
+
+//// add a few extra props for debugging
+//geojson.properties['__featureID'] = featureID;
+//geojson.properties['__tileID'] = `merged ${lowTile.id} and ${highTile.id}`;
+//geojson.properties['__prophash'] = prophash;
+
+      // More merging may be necessary
+      if (extent.min[0] < lowTileExtent.min[0])                   { this._queueMerge(cache, featureID, prophash, lowLeftEdge); }
+      if (isVertical && extent.max[0] > lowTileExtent.max[0])     { this._queueMerge(cache, featureID, prophash, lowRightEdge); }
+      if (isHorizontal && extent.min[1] < lowTileExtent.min[1])   { this._queueMerge(cache, featureID, prophash, lowBottomEdge); }
+      if (extent.max[1] > lowTileExtent.max[1])                   { this._queueMerge(cache, featureID, prophash, lowTopEdge); }
+      if (isVertical && extent.min[0] < highTileExtent.min[0])    { this._queueMerge(cache, featureID, prophash, highLeftEdge); }
+      if (extent.max[0] > highTileExtent.max[0])                  { this._queueMerge(cache, featureID, prophash, highRightEdge); }
+      if (extent.min[1] < highTileExtent.min[1])                  { this._queueMerge(cache, featureID, prophash, highBottomEdge); }
+      if (isHorizontal && extent.max[1] > highTileExtent.max[1])  { this._queueMerge(cache, featureID, prophash, highTopEdge); }
+
+      newFeatures.push({
+        id: featureID,
+        extent: extent,
+        layerID: source.layerID,
+        prophash: prophash,
+        geojson: geojsonRewind(geojson, true),
+        v: 0
+      });
+    }
+
+    if (newFeatures.length) {
+      this._cacheFeatures(cache, newFeatures);
+      this.context.deferredRedraw();
+    }
+  }
+
+
+  /**
+   * _calcExtent
+   * @param  {Object}  geojson - a GeoJSON Feature
+   * @return {Extent}
+   */
+  _calcExtent(geojson) {
+    const extent = new Extent();
+    const geometry = geojson?.geometry;
+    if (!geojson || !geometry) return extent;
+
+    const type = geometry.type;
+    const coords = geometry.coordinates;
+
+    // Treat single types as multi types to keep the code simple
+    const parts = /^Multi/.test(type) ? coords : [coords];
+
+    if (/Polygon$/.test(type)) {
+      for (const polygon of parts) {
+        const outer = polygon[0];  // No need to iterate over inners
+        for (const point of outer) {
+          _extend(point);
+        }
+      }
+    } else if (/LineString$/.test(type)) {
+      for (const line of parts) {
+        for (const point of line) {
+          _extend(point);
+        }
+      }
+    } else if (/Point$/.test(type)) {
+      for (const point of parts) {
+        _extend(point);
+      }
+    }
+
+    return extent;
+
+    // update extent in place
+    function _extend(coord) {
+      extent.min = [ Math.min(extent.min[0], coord[0]), Math.min(extent.min[1], coord[1]) ];
+      extent.max = [ Math.max(extent.max[0], coord[0]), Math.max(extent.max[1], coord[1]) ];
+    }
+  }
+
+
+  /**
+   * _dedupePoints
+   * The union operation often leaves points which are essentially coincident
+   * This will remove them in-place
+   * @param  {Object}  geojson - a GeoJSON Feature
+   */
+  _dedupePoints(geojson) {
+    const geometry = geojson?.geometry;
+    if (!geojson || !geometry) return;
+    if (geometry.type !== 'Polygon') return;
+
+    const EPSILON = 5e-6;
+    const coords = geometry.coordinates;
+
+    for (let i = 0; i < coords.length; i++) {
+      let ring = coords[i];
+      let cleaned = [];
+      let prevPoint = null;
+      for (let j = 0; j < ring.length; j++) {
+        const point = ring[j];
+        if (j === 0 || j === ring.length - 1) {   // leave first/last points alone
+          cleaned.push(point);
+        } else if (!vecEqual(point, prevPoint, EPSILON)) {
+          cleaned.push(point);
+        }
+        prevPoint = point;
+      }
+      coords[i] = cleaned;  // replace ring
+    }
+  }
+
+
+  /**
+   * _toSingleFeatures
+   * Call this to convert a multi feature to an array of single features
+   * (e.g. convert MultiPolygon to array of Polygons)
+   * (If passed a single feature, this will just return the single feature in an array)
+   * @param  {Object}  geojson - any GeoJSON Feature
+   * @return {Array} array of single GeoJSON features
+   */
+  _toSingleFeatures(geojson) {
+    const result = [];
+    const geometry = geojson?.geometry;
+    if (!geojson || !geometry) return result;
+
+    const type = geometry.type;
+    const coords = geometry.coordinates;
+
+    // Treat single types as multi types to keep the code simple
+    const parts = /^Multi/.test(type) ? coords : [coords];
+
+    for (const part of parts) {
+      result.push({
+        type: 'Feature',
+        id: geojson.id ?? undefined,
+        geometry: {
+          type: type.replace('Multi', ''),
+          coordinates: part
+        },
+        properties: Object.assign({}, geojson.properties)   // shallow copy
+      });
+    }
+    return result;
+  }
 }

--- a/modules/services/VectorTileService.js
+++ b/modules/services/VectorTileService.js
@@ -262,7 +262,6 @@ export class VectorTileService extends AbstractSystem {
           geometry.coordinates = [geometry.coordinates];
         }
 
-
         // Does this feature clip to tile bounds?
         // (there is probably a much more efficient way to determine this)
         let isClipped = false;

--- a/modules/ui/data_editor.js
+++ b/modules/ui/data_editor.js
@@ -49,13 +49,13 @@ export function uiDataEditor(context) {
       .merge(editor)
       .call(dataHeader.datum(_datum));
 
-    let rte = body.selectAll('.raw-tag-editor')
+    let rte = body.selectAll('.data-tag-editor')
       .data([0]);
 
     // enter/update
     rte.enter()
       .append('div')
-      .attr('class', 'raw-tag-editor data-editor')
+      .attr('class', 'data-tag-editor')
       .merge(rte)
       .call(rawTagEditor
         .tags((_datum && _datum.properties) || {})

--- a/modules/ui/data_header.js
+++ b/modules/ui/data_header.js
@@ -21,7 +21,8 @@ export function uiDataHeader(context) {
 
     iconEnter
       .append('div')
-      .call(uiIcon('#rapid-icon-data', 'note-fill'));
+      .attr('class', 'preset-icon-28')
+      .call(uiIcon('#rapid-icon-data'));
 
     headerEnter
       .append('div')

--- a/modules/ui/feature_list.js
+++ b/modules/ui/feature_list.js
@@ -149,7 +149,7 @@ export function uiFeatureList(context) {
         const entity = graph.hasEntity(id);
         if (!entity) continue;
 
-        const name = l10n.displayName(entity) || '';
+        const name = l10n.displayName(entity.tags) || '';
         if (name.toLowerCase().indexOf(q) < 0) continue;
 
         const matched = presets.match(entity, graph);

--- a/modules/ui/fields/restrictions.js
+++ b/modules/ui/fields/restrictions.js
@@ -605,7 +605,7 @@
 //
 //    function displayName(entityID, graph) {
 //        var entity = graph.entity(entityID);
-//        var name = l10n.displayName(entity) || '';
+//        var name = l10n.displayName(entity.tags) || '';
 //        var matched = context.systems.presets.match(entity, graph);
 //        var type = (matched && matched.name()) || l10n.displayType(entity.id);
 //        return name || type;

--- a/modules/ui/improveOSM_details.js
+++ b/modules/ui/improveOSM_details.js
@@ -84,7 +84,7 @@ export function uiImproveOsmDetails(context) {
         // Replace with friendly name if possible
         // (The entity may not yet be loaded into the graph)
         if (entity) {
-          let name = l10n.displayName(entity);  // try to use common name
+          let name = l10n.displayName(entity.tags);  // try to use common name
           if (!name && !isObjectLink) {
             const preset = presets.match(entity, context.graph());
             name = preset && !preset.isFallback() && preset.name();  // fallback to preset name

--- a/modules/ui/keepRight_details.js
+++ b/modules/ui/keepRight_details.js
@@ -88,7 +88,7 @@ export function uiKeepRightDetails(context) {
         // Replace with friendly name if possible
         // (The entity may not yet be loaded into the graph)
         if (entity) {
-          let name = l10n.displayName(entity);  // try to use common name
+          let name = l10n.displayName(entity.tags);  // try to use common name
           if (!name && !isObjectLink) {
             const preset = presets.match(entity, context.graph());
             name = preset && !preset.isFallback() && preset.name();  // fallback to preset name

--- a/modules/ui/osmose_details.js
+++ b/modules/ui/osmose_details.js
@@ -163,7 +163,7 @@ export function uiOsmoseDetails(context) {
             // Replace with friendly name if possible
             // (The entity may not yet be loaded into the graph)
             if (entity) {
-              let name = l10n.displayName(entity);  // try to use common name
+              let name = l10n.displayName(entity.tags);  // try to use common name
               if (!name) {
                 const preset = presets.match(entity, context.graph());
                 name = preset && !preset.isFallback() && preset.name();  // fallback to preset name

--- a/modules/ui/rapid_feature_inspector.js
+++ b/modules/ui/rapid_feature_inspector.js
@@ -20,7 +20,7 @@ export function uiRapidFeatureInspector(context, keybinding) {
     const hasTask = urlhash.initialHashParams.has('gpx');
     if (hasTask) return false;
 
-    // Power users aren't limited by the max featues limit
+    // Power users aren't limited by the max features limit
     const isPowerUser = urlhash.getParam('poweruser') === 'true';
     if (isPowerUser) return false;
 

--- a/modules/ui/sections/changes.js
+++ b/modules/ui/sections/changes.js
@@ -84,7 +84,7 @@ export function uiSectionChanges(context) {
       .append('span')
       .attr('class', 'entity-name')
       .html(d => {
-        const name = l10n.displayName(d.entity) || '';
+        const name = l10n.displayName(d.entity.tags);
         let string = '';
         if (name !== '') {
           string += ':';

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -186,7 +186,7 @@ export function uiSectionRawMemberEditor(context) {
                     labelLink
                         .append('span')
                         .attr('class', 'member-entity-name')
-                        .html(function(d) { return l10n.displayName(d.member); });
+                        .html(d => (d.member ? l10n.displayName(d.member.tags) : ''));
 
                     label
                         .append('button')

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -229,7 +229,7 @@ export function uiSectionRawMembershipEditor(context) {
         function baseDisplayLabel(entity) {
             var matched = presetSystem.match(entity, graph);
             var presetName = (matched && matched.name()) || l10n.t('inspector.relation');
-            var entityName = l10n.displayName(entity) || '';
+            var entityName = l10n.displayName(entity.tags) || '';
 
             return presetName + ' ' + entityName;
         }
@@ -336,7 +336,7 @@ export function uiSectionRawMembershipEditor(context) {
             .html(function(d) {
                 const matched = presetSystem.match(d.relation, context.graph());
                 // hide the network from the name if there is NSI match
-                return l10n.displayName(d.relation, matched.suggestion);
+                return l10n.displayName(d.relation.tags, matched.suggestion);
             });
 
         labelEnter

--- a/modules/ui/sections/selection_list.js
+++ b/modules/ui/sections/selection_list.js
@@ -114,7 +114,7 @@ export function uiSectionSelectionList(context) {
     items.selectAll('.entity-name')
       .html(d => {
         const entity = context.entity(d.id);  // current version of the entity
-        return l10n.displayName(entity);
+        return l10n.displayName(entity.tags);
       });
   }
 

--- a/modules/ui/settings/custom_data.js
+++ b/modules/ui/settings/custom_data.js
@@ -5,114 +5,120 @@ import { utilNoAuto, utilRebind } from '../../util';
 
 
 export function uiSettingsCustomData(context) {
-    const prefs = context.systems.storage;
-    var dispatch = d3_dispatch('change');
+  const storage = context.systems.storage;
+  let dispatch = d3_dispatch('change');
 
-    function render(selection) {
-        var dataLayer = context.scene().layers.get('custom-data');
+  const accept = [
+    '.gpx', 'application/gpx', 'application/gpx+xml',
+    '.kml', 'application/vnd.google-earth.kml+xml', 'application/kml', 'application/kml+xml',
+    '.geojson', '.json', 'application/geo+json', 'application/json', 'application/vnd.geo+json', 'text/x-json'
+  ];
 
-        // keep separate copies of original and current settings
-        var _origSettings = {
-            fileList: (dataLayer && dataLayer.fileList()) || null,
-            url: prefs.getItem('settings-custom-data-url')
-        };
-        var _currSettings = Object.assign({}, _origSettings);
+  function render(selection) {
+    let dataLayer = context.scene().layers.get('custom-data');
 
-        // var example = 'https://{switch:a,b,c}.tile.openstreetmap.org/{zoom}/{x}/{y}.png';
-        var modal = uiConfirm(context, selection).okButton();
-
-        modal
-            .classed('settings-modal settings-custom-data', true);
-
-        modal.select('.modal-section.header')
-            .append('h3')
-            .html(context.tHtml('settings.custom_data.header'));
+    // Keep separate copies of original and current settings
+    let _origSettings = {
+      fileList: (dataLayer && dataLayer.fileList()) || null,
+      url: storage.getItem('settings-custom-data-url')
+    };
+    let _currSettings = Object.assign({}, _origSettings);
 
 
-        var textSection = modal.select('.modal-section.message-text');
+    const modal = uiConfirm(context, selection).okButton();
 
-        textSection
-            .append('pre')
-            .attr('class', 'instructions-file')
-            .html(context.tHtml('settings.custom_data.file.instructions'));
+    modal
+      .classed('settings-modal settings-custom-data', true);
 
-        textSection
-            .append('input')
-            .attr('class', 'field-file')
-            .attr('type', 'file')
-            .property('files', _currSettings.fileList)  // works for all except IE11
-            .on('change', function(d3_event) {
-                var files = d3_event.target.files;
-                if (files && files.length) {
-                    _currSettings.url = '';
-                    textSection.select('.field-url').property('value', '');
-                    _currSettings.fileList = files;
-                } else {
-                    _currSettings.fileList = null;
-                }
-            });
-
-        textSection
-            .append('h4')
-            .html(context.tHtml('settings.custom_data.or'));
-
-        textSection
-            .append('pre')
-            .attr('class', 'instructions-url')
-            .html(context.tHtml('settings.custom_data.url.instructions'));
-
-        textSection
-            .append('textarea')
-            .attr('class', 'field-url')
-            .attr('placeholder', context.t('settings.custom_data.url.placeholder'))
-            .call(utilNoAuto)
-            .property('value', _currSettings.url);
+    modal.select('.modal-section.header')
+      .append('h3')
+      .html(context.tHtml('settings.custom_data.header'));
 
 
-        // insert a cancel button
-        var buttonSection = modal.select('.modal-section.buttons');
+    const textSection = modal.select('.modal-section.message-text');
 
-        buttonSection
-            .insert('button', '.ok-button')
-            .attr('class', 'button cancel-button secondary-action')
-            .html(context.tHtml('confirm.cancel'));
+    textSection
+      .append('pre')
+      .attr('class', 'instructions-file')
+      .html(context.tHtml('settings.custom_data.file.instructions'));
 
-
-        buttonSection.select('.cancel-button')
-            .on('click.cancel', clickCancel);
-
-        buttonSection.select('.ok-button')
-            .attr('disabled', isSaveDisabled)
-            .on('click.save', clickSave);
-
-
-        function isSaveDisabled() {
-            return null;
+    textSection
+      .append('input')
+      .attr('class', 'field-file')
+      .attr('type', 'file')
+      .attr('accept', accept.join())
+      .property('files', _currSettings.fileList)  // works for all except IE11
+      .on('change', d3_event => {
+        const files = d3_event.target.files;
+        if (files?.length) {
+          _currSettings.url = '';
+          textSection.select('.field-url').property('value', '');
+          _currSettings.fileList = files;
+        } else {
+          _currSettings.fileList = null;
         }
+      });
+
+    textSection
+      .append('h4')
+      .html(context.tHtml('settings.custom_data.or'));
+
+    textSection
+      .append('pre')
+      .attr('class', 'instructions-url')
+      .html(context.tHtml('settings.custom_data.url.instructions'));
+
+    textSection
+      .append('textarea')
+      .attr('class', 'field-url')
+      .attr('placeholder', context.t('settings.custom_data.url.placeholder'))
+      .call(utilNoAuto)
+      .property('value', _currSettings.url);
 
 
-        // restore the original url
-        function clickCancel() {
-            textSection.select('.field-url').property('value', _origSettings.url);
-            prefs.setItem('settings-custom-data-url', _origSettings.url);
-            this.blur();
-            modal.close();
-        }
+    // Setup Ok/Cancel buttons
+    const buttonSection = modal.select('.modal-section.buttons');
 
-        // accept the current url
-        function clickSave() {
-            _currSettings.url = textSection.select('.field-url').property('value').trim();
+    buttonSection
+      .insert('button', '.ok-button')
+      .attr('class', 'button cancel-button secondary-action')
+      .html(context.tHtml('confirm.cancel'));
 
-            // one or the other but not both
-            if (_currSettings.url) { _currSettings.fileList = null; }
-            if (_currSettings.fileList) { _currSettings.url = ''; }
+    buttonSection.select('.cancel-button')
+      .on('click.cancel', clickCancel);
 
-            prefs.setItem('settings-custom-data-url', _currSettings.url);
-            this.blur();
-            modal.close();
-            dispatch.call('change', this, _currSettings);
-        }
+    buttonSection.select('.ok-button')
+      .attr('disabled', isSaveDisabled)
+      .on('click.save', clickSave);
+
+
+    function isSaveDisabled() {  // why is this here?
+      return null;
     }
 
-    return utilRebind(render, dispatch, 'on');
+
+    // Restore the original settings
+    function clickCancel() {
+      textSection.select('.field-url').property('value', _origSettings.url);
+      storage.setItem('settings-custom-data-url', _origSettings.url);
+      this.blur();
+      modal.close();
+    }
+
+    // Accept the current settings
+    function clickSave() {
+      _currSettings.url = textSection.select('.field-url').property('value').trim();
+
+      // One or the other but not both
+      if (_currSettings.url)       { _currSettings.fileList = null; }
+      if (_currSettings.fileList)  { _currSettings.url = '';        }
+
+      storage.setItem('settings-custom-data-url', _currSettings.url);
+      this.blur();
+      modal.close();
+      dispatch.call('change', this, _currSettings);
+    }
+  }
+
+  return utilRebind(render, dispatch, 'on');
 }

--- a/modules/util/fetch_response.js
+++ b/modules/util/fetch_response.js
@@ -42,23 +42,26 @@ export function utilFetchResponse(response) {
 
   const contentType = response.headers.get('content-type').split(';')[0];
   switch (contentType) {
+    case 'application/geo+json':
     case 'application/json':
+    case 'application/vnd.geo+json':
+    case 'text/x-json':
       if (response.status === 204 || response.status === 205) return;  // No Content, Reset Content
       return response.json();
 
     // see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
+    case 'application/xhtml+xml':
+    case 'application/xml':
+    case 'image/svg+xml':
     case 'text/html':
     case 'text/xml':
-    case 'application/xml':
-    case 'application/xhtml+xml':
-    case 'image/svg+xml':
       return response.text()
         .then(txt => new window.DOMParser().parseFromString(txt, contentType));
 
     case 'application/octet-stream':
-    case 'application/x-protobuf':
     case 'application/protobuf':
     case 'application/vnd.google.protobuf':
+    case 'application/x-protobuf':
       return response.arrayBuffer();
 
     default:

--- a/modules/util/fetch_response.js
+++ b/modules/util/fetch_response.js
@@ -61,6 +61,7 @@ export function utilFetchResponse(response) {
     case 'application/octet-stream':
     case 'application/protobuf':
     case 'application/vnd.google.protobuf':
+    case 'application/vnd.mapbox-vector-tile':
     case 'application/x-protobuf':
       return response.arrayBuffer();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "pbf": "^3.2.1",
         "pixi-filters": "5.2.1",
         "pixi.js": "7.2.4",
+        "pmtiles": "^2.10.0",
         "polygon-clipping": "~0.15.3",
         "prop-types": "^15.8.1",
         "rbush": "3.0.1",
@@ -4411,6 +4412,11 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -8107,6 +8113,14 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pmtiles": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-2.10.0.tgz",
+      "integrity": "sha512-X+s6JyperpcAkKwv55MKx72ckOUB0ZjcfK4929iM0SS0MkLydEi2FSW1E8YTE1E2XaZ2TVk/MIUrbsZuXV7K2g==",
+      "dependencies": {
+        "fflate": "^0.8.0"
       }
     },
     "node_modules/polygon-clipping": {
@@ -13779,6 +13793,11 @@
         "whatwg-url": "^6.5.0"
       }
     },
+    "fflate": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg=="
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -16239,6 +16258,14 @@
     "playwright-core": {
       "version": "1.36.0",
       "dev": true
+    },
+    "pmtiles": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-2.10.0.tgz",
+      "integrity": "sha512-X+s6JyperpcAkKwv55MKx72ckOUB0ZjcfK4929iM0SS0MkLydEi2FSW1E8YTE1E2XaZ2TVk/MIUrbsZuXV7K2g==",
+      "requires": {
+        "fflate": "^0.8.0"
+      }
     },
     "polygon-clipping": {
       "version": "0.15.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "pbf": "^3.2.1",
     "pixi-filters": "5.2.1",
     "pixi.js": "7.2.4",
+    "pmtiles": "^2.10.0",
     "polygon-clipping": "~0.15.3",
     "prop-types": "^15.8.1",
     "rbush": "3.0.1",

--- a/test/spec/core/LocalizationSystem.test.js
+++ b/test/spec/core/LocalizationSystem.test.js
@@ -42,68 +42,68 @@ describe('LocalizationSystem', () => {
 
   describe('#displayName', () => {
     it('returns the name if tagged with a name', () => {
-      const entity = { tags: { name: 'East Coast Greenway' }};
-      expect(_l10n.displayName(entity)).to.eql('East Coast Greenway');
+      const tags = { name: 'East Coast Greenway' };
+      expect(_l10n.displayName(tags)).to.eql('East Coast Greenway');
     });
 
     it('returns just the name for non-routes', () => {
-      const entity = { tags: { name: 'Abyssinian Room', ref: '260-115' }};
-      expect(_l10n.displayName(entity)).to.eql('Abyssinian Room');
+      const tags = { name: 'Abyssinian Room', ref: '260-115' };
+      expect(_l10n.displayName(tags)).to.eql('Abyssinian Room');
     });
 
     it('returns the name and the ref for routes', () => {
-      const entity1 = { tags: { name: 'Lynfield Express', ref: '25L', route: 'bus' }};
-      expect(_l10n.displayName(entity1)).to.eql('25L: Lynfield Express');
-      const entity2 = { tags: { name: 'Kāpiti Expressway', ref: 'SH1', route: 'road' }};
-      expect(_l10n.displayName(entity2)).to.eql('SH1: Kāpiti Expressway');
+      const tags1 = { name: 'Lynfield Express', ref: '25L', route: 'bus' };
+      expect(_l10n.displayName(tags1)).to.eql('25L: Lynfield Express');
+      const tags2 = { name: 'Kāpiti Expressway', ref: 'SH1', route: 'road' };
+      expect(_l10n.displayName(tags2)).to.eql('SH1: Kāpiti Expressway');
     });
 
     it('returns the name, ref, and network for routes', () => {
-      const entity = { tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }};
-      expect(_l10n.displayName(entity)).to.eql('AT 25L: Lynfield Express');
+      const tags = { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' };
+      expect(_l10n.displayName(tags)).to.eql('AT 25L: Lynfield Express');
     });
 
     it('does not use the network tag if the hideNetwork argument is true', () => {
-      const entity1 = { tags: { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' }};
-      expect(_l10n.displayName(entity1, true)).to.eql('25L: Lynfield Express');
-      const entity2 = { tags: { network: 'SORTA', ref: '3X' }};
-      expect(_l10n.displayName(entity2, true)).to.eql('3X');
+      const tags1 = { name: 'Lynfield Express', ref: '25L', network: 'AT', route: 'bus' };
+      expect(_l10n.displayName(tags1, true)).to.eql('25L: Lynfield Express');
+      const tags2 = { network: 'SORTA', ref: '3X' };
+      expect(_l10n.displayName(tags2, true)).to.eql('3X');
     });
 
     it('distinguishes unnamed features by ref', () => {
-      const entity = { tags: { ref: '66' }};
-      expect(_l10n.displayName(entity)).to.eql('66');
+      const tags = { ref: '66' };
+      expect(_l10n.displayName(tags)).to.eql('66');
     });
 
     it('distinguishes unnamed features by network or cycle_network', () => {
-      const entity1 = { tags: { network: 'SORTA', ref: '3X' }};
-      expect(_l10n.displayName(entity1)).to.eql('SORTA 3X');
-      const entity2 = { tags: { network: 'ncn', cycle_network: 'US:US', ref: '76' }};
-      expect(_l10n.displayName(entity2)).to.eql('US:US 76');
+      const tags1 = { network: 'SORTA', ref: '3X' };
+      expect(_l10n.displayName(tags1)).to.eql('SORTA 3X');
+      const tags2 = { network: 'ncn', cycle_network: 'US:US', ref: '76' };
+      expect(_l10n.displayName(tags2)).to.eql('US:US 76');
     });
 
     it('distinguishes unnamed routes by direction', () => {
-      const entity1 = { tags: { network: 'US:US', ref: '66', direction: 'west', route: 'road' }};
-      expect(_l10n.displayName(entity1)).to.eql('US:US 66 west');
-      const entity2 = { tags: { network: 'Marguerite', ref: 'X', direction: 'anticlockwise', route: 'bus' }};
-      expect(_l10n.displayName(entity2)).to.eql('Marguerite X anticlockwise');
+      const tags1 = { network: 'US:US', ref: '66', direction: 'west', route: 'road' };
+      expect(_l10n.displayName(tags1)).to.eql('US:US 66 west');
+      const tags2 = { network: 'Marguerite', ref: 'X', direction: 'anticlockwise', route: 'bus' };
+      expect(_l10n.displayName(tags2)).to.eql('Marguerite X anticlockwise');
     });
 
     it('distinguishes unnamed routes by waypoints', () => {
-      const entity1 = { tags: { network: 'SORTA', ref: '3X', from: 'Downtown', route: 'bus' }};
-      expect(_l10n.displayName(entity1)).to.eql('SORTA 3X');
-      const entity2 = { tags: { network: 'SORTA', ref: '3X', to: 'Kings Island', route: 'bus' }};
-      expect(_l10n.displayName(entity2)).to.eql('SORTA 3X');
-      const entity3 = { tags: {network: 'SORTA', ref: '3X', via: 'Montgomery', route: 'bus' }};
-      expect(_l10n.displayName(entity3)).to.eql('SORTA 3X');
+      const tags1 = { network: 'SORTA', ref: '3X', from: 'Downtown', route: 'bus' };
+      expect(_l10n.displayName(tags1)).to.eql('SORTA 3X');
+      const tags2 = { network: 'SORTA', ref: '3X', to: 'Kings Island', route: 'bus' };
+      expect(_l10n.displayName(tags2)).to.eql('SORTA 3X');
+      const tags3 = {network: 'SORTA', ref: '3X', via: 'Montgomery', route: 'bus' };
+      expect(_l10n.displayName(tags3)).to.eql('SORTA 3X');
 
       // Green Line: Old Ironsides => Winchester
-      const entity4 = { tags: { network: 'VTA', ref: 'Green', from: 'Old Ironsides', to: 'Winchester', route: 'bus' }};
-      expect(_l10n.displayName(entity4)).to.eql('VTA Green from Old Ironsides to Winchester');
+      const tags4 = { network: 'VTA', ref: 'Green', from: 'Old Ironsides', to: 'Winchester', route: 'bus' };
+      expect(_l10n.displayName(tags4)).to.eql('VTA Green from Old Ironsides to Winchester');
 
       // BART Yellow Line: Antioch => Pittsburg/Bay Point => SFO Airport => Millbrae
-      const entity5 = { tags: { network: 'BART', ref: 'Yellow', from: 'Antioch', to: 'Millbrae', via: 'Pittsburg/Bay Point;San Francisco International Airport', route: 'subway' }};
-      expect(_l10n.displayName(entity5)).to.eql('BART Yellow from Antioch to Millbrae via Pittsburg/Bay Point;San Francisco International Airport');
+      const tags5 = { network: 'BART', ref: 'Yellow', from: 'Antioch', to: 'Millbrae', via: 'Pittsburg/Bay Point;San Francisco International Airport', route: 'subway' };
+      expect(_l10n.displayName(tags5)).to.eql('BART Yellow from Antioch to Millbrae via Pittsburg/Bay Point;San Francisco International Airport');
     });
   });
 });

--- a/test/spec/services/NominatimService.test.js
+++ b/test/spec/services/NominatimService.test.js
@@ -55,7 +55,7 @@ describe('NominatimService', () => {
         );
         expect(callback).to.have.been.calledWithExactly(null, 'at');
         done();
-      }, 50);
+      }, 20);
     });
   });
 

--- a/test/spec/services/OsmWikibaseService.test.js
+++ b/test/spec/services/OsmWikibaseService.test.js
@@ -1,10 +1,10 @@
 describe('OsmWikibaseService', () => {
-  let wikibase;
+  let _wikibase;
 
   beforeEach(() => {
     fetchMock.reset();
-    wikibase = new Rapid.OsmWikibaseService();
-    return wikibase.initAsync();
+    _wikibase = new Rapid.OsmWikibaseService();
+    return _wikibase.initAsync();
   });
 
 
@@ -247,7 +247,7 @@ describe('OsmWikibaseService', () => {
 
   const localeData = {
     id: 'Q7792',
-    sitelinks: {wiki: {site: 'wiki', title: 'Locale:fr'}}
+    sitelinks: { wiki: { site: 'wiki', title: 'Locale:fr' } }
   };
 
   describe('#getEntity', () => {
@@ -266,7 +266,7 @@ describe('OsmWikibaseService', () => {
         headers: { 'Content-Type': 'application/json' }
     });
 
-      wikibase.getEntity({ key: 'amenity', value: 'parking', langCodes: ['fr'] }, callback);
+      _wikibase.getEntity({ key: 'amenity', value: 'parking', langCodes: ['fr'] }, callback);
 
       window.setTimeout(() => {
         expect(parseQueryString(fetchMock.lastUrl())).to.eql(
@@ -285,32 +285,32 @@ describe('OsmWikibaseService', () => {
           tag: tagData()
         });
         done();
-      }, 50);
+      }, 20);
     });
   });
 
 
   it('creates correct sitelinks', () => {
-    expect(wikibase.toSitelink('amenity')).to.eql('Key:amenity');
-    expect(wikibase.toSitelink('amenity_')).to.eql('Key:amenity');
-    expect(wikibase.toSitelink('_amenity_')).to.eql('Key: amenity');
-    expect(wikibase.toSitelink('amenity or_not_')).to.eql('Key:amenity or not');
-    expect(wikibase.toSitelink('amenity', 'parking')).to.eql('Tag:amenity=parking');
-    expect(wikibase.toSitelink(' amenity_', '_parking_')).to.eql('Tag: amenity = parking');
-    expect(wikibase.toSitelink('amenity or_not', '_park ing_')).to.eql('Tag:amenity or not= park ing');
+    expect(_wikibase.toSitelink('amenity')).to.eql('Key:amenity');
+    expect(_wikibase.toSitelink('amenity_')).to.eql('Key:amenity');
+    expect(_wikibase.toSitelink('_amenity_')).to.eql('Key: amenity');
+    expect(_wikibase.toSitelink('amenity or_not_')).to.eql('Key:amenity or not');
+    expect(_wikibase.toSitelink('amenity', 'parking')).to.eql('Tag:amenity=parking');
+    expect(_wikibase.toSitelink(' amenity_', '_parking_')).to.eql('Tag: amenity = parking');
+    expect(_wikibase.toSitelink('amenity or_not', '_park ing_')).to.eql('Tag:amenity or not= park ing');
   });
 
   it('gets correct value from entity', () => {
-    wikibase.addLocale('de', 'Q6994');
-    wikibase.addLocale('fr', 'Q7792');
-    expect(wikibase.claimToValue(tagData(), 'P4', 'en')).to.eql('Primary image.jpg');
-    expect(wikibase.claimToValue(keyData(), 'P6', 'en')).to.eql('Q15');
-    expect(wikibase.claimToValue(keyData(), 'P6', 'fr')).to.eql('Q15');
-    expect(wikibase.claimToValue(keyData(), 'P6', 'de')).to.eql('Q14');
+    _wikibase.addLocale('de', 'Q6994');
+    _wikibase.addLocale('fr', 'Q7792');
+    expect(_wikibase.claimToValue(tagData(), 'P4', 'en')).to.eql('Primary image.jpg');
+    expect(_wikibase.claimToValue(keyData(), 'P6', 'en')).to.eql('Q15');
+    expect(_wikibase.claimToValue(keyData(), 'P6', 'fr')).to.eql('Q15');
+    expect(_wikibase.claimToValue(keyData(), 'P6', 'de')).to.eql('Q14');
   });
 
   it('gets monolingual value from entity as an object', () => {
-    expect(wikibase.monolingualClaimToValueObj(tagData(), 'P31')).to.eql({
+    expect(_wikibase.monolingualClaimToValueObj(tagData(), 'P31')).to.eql({
       cs: 'Cs:Key:bridge:movable',
       de: 'DE:Key:bridge:movable',
       fr: 'FR:Key:bridge:movable',

--- a/test/spec/services/TaginfoService.test.js
+++ b/test/spec/services/TaginfoService.test.js
@@ -51,7 +51,7 @@ describe('TaginfoService', () => {
         );
         expect(callback).to.have.been.calledWith(null, [{ title: 'amenity', value: 'amenity' }] );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes popular keys', done => {
@@ -68,7 +68,7 @@ describe('TaginfoService', () => {
       window.setTimeout(() => {
         expect(callback).to.have.been.calledWith(null, [{ title: 'amenity', value: 'amenity' }] );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes popular keys with an entity type filter', done => {
@@ -85,7 +85,7 @@ describe('TaginfoService', () => {
       window.setTimeout(() => {
         expect(callback).to.have.been.calledWith(null, [{ title: 'amenity', value: 'amenity' }] );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes unpopular keys with a wiki page', done => {
@@ -105,7 +105,7 @@ describe('TaginfoService', () => {
           { title: 'amenityother', value: 'amenityother' }
         ]);
         done();
-      }, 50);
+      }, 20);
     });
 
     it('sorts keys with \':\' below keys without \':\'', done => {
@@ -124,7 +124,7 @@ describe('TaginfoService', () => {
           null, [{ title: 'ref', value: 'ref' }, { title: 'ref:bag', value: 'ref:bag' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
   });
 
@@ -147,7 +147,7 @@ describe('TaginfoService', () => {
           null, [{ title: 'recycling:glass', value: 'recycling:glass' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('excludes multikeys with extra colons', done => {
@@ -166,7 +166,7 @@ describe('TaginfoService', () => {
           null, [{ title: 'service:bicycle:retail', value: 'service:bicycle:retail' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('excludes multikeys with wrong prefix', done => {
@@ -185,7 +185,7 @@ describe('TaginfoService', () => {
           null, [{ title: 'service:bicycle:retail', value: 'service:bicycle:retail' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
   });
 
@@ -208,7 +208,7 @@ describe('TaginfoService', () => {
           null, [{ value: 'parking', title: 'A place for parking cars' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes popular values', done => {
@@ -227,7 +227,7 @@ describe('TaginfoService', () => {
           null, [{ value: 'parking', title: 'A place for parking cars' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('does not get values for extremely popular keys', done => {
@@ -244,7 +244,7 @@ describe('TaginfoService', () => {
       window.setTimeout(() => {
         expect(callback).to.have.been.calledWith(null, []);
         done();
-      }, 50);
+      }, 20);
     });
 
     it('excludes values with capital letters and some punctuation', done => {
@@ -266,7 +266,7 @@ describe('TaginfoService', () => {
           null, [{ value: 'parking', title: 'A place for parking cars' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes network values with capital letters and some punctuation', done => {
@@ -292,7 +292,7 @@ describe('TaginfoService', () => {
           { value: 'US:MD', title: 'State highways in the U.S. state of Maryland.' }
         ]);
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes biological genus values with capital letters', done => {
@@ -308,7 +308,7 @@ describe('TaginfoService', () => {
       window.setTimeout(() => {
         expect(callback).to.have.been.calledWith(null, [{ value: 'Quercus', title: 'Oak' }] );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes biological taxon values with capital letters', done => {
@@ -324,7 +324,7 @@ describe('TaginfoService', () => {
       window.setTimeout(() => {
         expect(callback).to.have.been.calledWith(null, [{ value: 'Quercus robur', title: 'Oak' }] );
         done();
-      }, 50);
+      }, 20);
     });
 
     it('includes biological species values with capital letters', done => {
@@ -340,7 +340,7 @@ describe('TaginfoService', () => {
       window.setTimeout(() => {
         expect(callback).to.have.been.calledWith(null, [{ value: 'Quercus robur', title: 'Oak' }] );
         done();
-      }, 50);
+      }, 20);
     });
   });
 
@@ -365,7 +365,7 @@ describe('TaginfoService', () => {
           { value: 'south', title: 'south' }
         ]);
         done();
-      }, 50);
+      }, 20);
     });
   });
 
@@ -386,7 +386,7 @@ describe('TaginfoService', () => {
           null, [{ on_way: false, lang: 'en', on_area: true, image: 'File:Car park2.jpg' }]
         );
         done();
-      }, 50);
+      }, 20);
     });
   });
 


### PR DESCRIPTION
### tl;dr

This PR includes a massive refresh of the vector tile support in Rapid, and adds support for Protomaps PMTiles URLs!

### Why

Overture Map Foundation has [recently released](https://overturemaps.org/overture-maps-foundation-releases-first-world-wide-open-map-dataset/) a whole lot of data under a permissive license.  Yay! 🎉   
Like everyone else, we're really interested to see how this data looks on a map. 
 
Shout out to @jenningsanderson and @bdon for building these demos that do exactly that:
- https://jenningsanderson.com/overture-daylight-mvp/#16.14/47.605721/-122.327055
- https://bdon.github.io/overture-tiles/places.html#16.14/47.605721/-122.327055

Both of these demos are powered by [Protomaps PMTiles](https://protomaps.com/docs/pmtiles) - a newish single-file format for storing vector tiles in the cloud.  It's like Mapbox Vector Tiles (MVT), but a map client can use HTTP Range Requests to get just the data you need from the archive. 

This PR adds support for .pmtiles sources in our "Custom Map Data" layers - this is the part of the Rapid code responsible for rendering custom .geojson, .kml, .gpx, files - and also connecting to vector tile sources of data.  

👉  **Importantly - the data is view-only for now.**  
This PR is not a solution for ingesting third party data into OSM, or bring-your-own-data, or anything like that.
You can connect to a PMTiles URL and look at what's in it, that's all!

Here are some .pmtiles URLs to try (no guarantees!):
```
https://jenningsanderson.com/overture-daylight-mvp/places.pmtiles
https://jenningsanderson.com/overture-daylight-mvp/buildings_z13.pmtiles
 https://jenningsanderson.com/overture-daylight-mvp/roads_z11.pmtiles
https://r2-public.protomaps.com/protomaps-sample-datasets/overture-pois.pmtiles
```

#### Overture Places around Newark, NJ
<img width="1670" alt="Screenshot 2023-08-10 at 4 20 51 PM" src="https://github.com/facebook/Rapid/assets/38784/6418410a-5d81-4e97-992c-2f1c648119c4">


I also did some much-needed refresh of Rapid's vector tile code.  It's a lot more performant now, and it does a better job stitching together features across tile boundaries.  Take a peek into your favorite vector tile map!

#### OSM Americana around Newark, NJ
<img width="1673" alt="Screenshot 2023-08-10 at 4 29 42 PM" src="https://github.com/facebook/Rapid/assets/38784/2ea8c515-882b-440f-a626-d9b300c254fb">


### What next
Many things that we can ticket separately
- bring-your-own-data #585
- improve/customize the styling of the vector data (it's all cyan for now)
- There are still bugs with stitching linestrings and polygons. 

