### PR TITLE
refactor: replace text to html

### DIFF
--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -384,7 +384,7 @@ export function uiCombobox(context, klass) {
                     return 'combobox-option ' + (d.klass || '');
                 })
                 .attr('title', function(d) { return d.title; })
-                .text(function(d) { return d.display || d.value; })
+                .html(function(d) { return d.display || d.value; })
                 .on('mouseenter', _mouseEnterHandler)
                 .on('mouseleave', _mouseLeaveHandler)
                 .merge(options)


### PR DESCRIPTION
### Description

This PR reverts the change to leave the combo box content displaying HTML, as it is frequently used to display rich content. This ensures compatibility with existing use cases while maintaining the ability to render HTML within the combo box.

Fixes #1161