### PR TITLE
chore: create PR template for improved submission clarity

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,71 @@
+## Description
+
+<!-- 
+Please do not leave this blank 
+This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
+-->
+
+## What type of PR is this? (check all applicable)
+
+- [ ] 🍕 Feature
+- [ ] 🐛 Bug Fix
+- [ ] 📝 Documentation Update
+- [ ] 🎨 Style
+- [ ] 🧑‍💻 Code Refactor
+- [ ] 🔥 Performance Improvements
+- [ ] ✅ Test
+- [ ] 🤖 Build
+- [ ] 🔁 CI
+- [ ] 📦 Chore (Release)
+- [ ] ⏩ Revert
+
+## Related Tickets & Documents
+<!-- 
+Please use this format link issue numbers: Fixes #123
+https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
+-->
+
+## Mobile & Desktop Screenshots/Recordings
+
+<!-- Visual changes require screenshots -->
+
+
+## Added tests?
+
+- [ ] 👍 yes
+- [ ] 🙅 no, because they aren't needed
+- [ ] 🙋 no, because I need help
+
+## Added to documentation?
+
+- [ ] 📜 README.md
+- [ ] 📓 docs.opensauced.pizza
+- [ ] 🍕 dev.to/opensauced
+- [ ] 📕 storybook
+- [ ] 🙅 no documentation needed
+
+## [optional] Are there any post-deployment tasks we need to perform?
+
+
+
+## [optional] What gif best describes this PR or how it makes you feel?
+
+
+
+<!-- note: PRs with deleted sections will be marked invalid -->
+
+<!--
+  For Work In Progress Pull Requests, please use the Draft PR feature,
+  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
+  
+  For a timely review/response, please avoid force-pushing additional
+  commits if your PR already received reviews or comments.
+  
+  Before submitting a Pull Request, please ensure you've done the following:
+  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
+  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
+  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
+  - ✅ Provide tests for your changes.
+  - 📝 Use descriptive commit messages.
+  - 📗 Update any related documentation and include any relevant screenshots.
+-->


### PR DESCRIPTION
In this PR, I created a PR template to enhance the clarity of PR submissions. It introduces standardized sections and checkboxes for contributors to specify the type of PR (e.g., feature, bug fix, documentation update), reference related issues or documents, provide mobile and desktop screenshots or recordings for visual changes, indicate whether tests and documentation have been added, and add any post-deployment tasks or GIFs for additional context.

Fixes #1163