### PR TITLE
Url zoom, A fix for issue #1108 

### DIFF
--- a/modules/core/UrlHashSystem.js
+++ b/modules/core/UrlHashSystem.js
@@ -151,6 +151,7 @@ export class UrlHashSystem extends AbstractSystem {
     this._updateHash();   // make sure hash matches the _currParams
     this._hashchange();   // emit 'hashchange' so other code knows what the hash contains
     this._updateTitle();
+    this._runOnceAtStartup();
   }
 
 
@@ -213,26 +214,6 @@ export class UrlHashSystem extends AbstractSystem {
       this.deferredUpdateHash();
     }
   }
-
-  /**
-   * runOnceAtStartup
-   * Called once startup is complete
-   * This will zoom into the object from the URL hash if there is any present
-   */
-  runOnceAtStartup() {
-    // const toOmit = ['comment', 'source', 'hashtags', 'walkthrough'];
-    // let params = utilObjectOmit(Object.fromEntries(this._currParams), toOmit);
-    const extent = context.mode?.extent;
-    const map = context.systems.map;
-    if (extent) {   // zoom in on extent
-      _lastTransform = map.transform();
-      const [w, h] = map.dimensions;
-      const z = map.extentZoom(extent, [w/2, h/2]);
-      map.centerZoomEase(extent.center(), z);
-
-    }
-  }
-
 
   /**
    * _updateHash
@@ -323,4 +304,21 @@ export class UrlHashSystem extends AbstractSystem {
 
     this.emit('hashchange', new Map(this._currParams), new Map(this._prevParams));  // emit copies
   }
+
+  /**
+   * runOnceAtStartup
+   * Called once startup is complete
+   * This will zoom into the object from the URL hash if there is any present
+   */
+  _runOnceAtStartup() {
+    const extent = context.mode?.extent;
+    const map = context.systems.map;
+    if (extent) {   // zoom in on extent
+      _lastTransform = map.transform();
+      const [w, h] = map.dimensions;
+      const z = map.extentZoom(extent, [w/2, h/2]);
+      map.centerZoomEase(extent.center(), z);
+    }
+  }
 }
+

--- a/modules/core/UrlHashSystem.js
+++ b/modules/core/UrlHashSystem.js
@@ -214,6 +214,25 @@ export class UrlHashSystem extends AbstractSystem {
     }
   }
 
+  /**
+   * runOnceAtStartup
+   * Called once startup is complete
+   * This will zoom into the object from the URL hash if there is any present
+   */
+  runOnceAtStartup() {
+    // const toOmit = ['comment', 'source', 'hashtags', 'walkthrough'];
+    // let params = utilObjectOmit(Object.fromEntries(this._currParams), toOmit);
+    const extent = context.mode?.extent;
+    const map = context.systems.map;
+    if (extent) {   // zoom in on extent
+      _lastTransform = map.transform();
+      const [w, h] = map.dimensions;
+      const z = map.extentZoom(extent, [w/2, h/2]);
+      map.centerZoomEase(extent.center(), z);
+
+    }
+  }
+
 
   /**
    * _updateHash

--- a/modules/services/VectorTileService.js
+++ b/modules/services/VectorTileService.js
@@ -1,3 +1,4 @@
+
 import { Extent, Tiler, vecEqual } from '@rapid-sdk/math';
 import { utilHashcode } from '@rapid-sdk/util';
 import { VectorTile } from '@mapbox/vector-tile';


### PR DESCRIPTION
## Description

A fix for issue #1108:

For URLs with an object id such as rapideditor.org/rapid#id=w1204555438 users must pres Z to zoom into the object with id w1204555438

This fix zooms to the object automatically once the map is loaded.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [✅] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

https://github.com/facebook/Rapid/issues/1108

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/facebook/Rapid/assets/2739245/60320a24-f812-4f8c-94b6-9dec9ecd76be)

## Added tests?

- [ ] 👍 yes
- [✅] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [✅] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
