### PR TITLE
Added 3D map toggle from URL hash, feature from issue #1068

### DIFF
--- a/modules/core/Map3dSystem.js
+++ b/modules/core/Map3dSystem.js
@@ -28,6 +28,7 @@ export class Map3dSystem extends AbstractSystem {
     this._loadPromise = null;
     this._startPromise = null;
 
+    // this._hashchange = this._hashchange.bind(this);
     this.building3dlayerSpec = this.get3dBuildingLayerSpec('3D Buildings', 'osmbuildings');
     this.roadStrokelayerSpec = this.getRoadStrokeLayerSpec('Roads', 'osmroads');
     this.roadCasinglayerSpec = this.getRoadCasingLayerSpec('Roads', 'osmroads');
@@ -47,6 +48,7 @@ export class Map3dSystem extends AbstractSystem {
         return Promise.reject(`Cannot init:  ${this.id} requires ${id}`);
       }
     }
+    // context.systems.urlhash.on('hashchange', this._hashchange);
     return Promise.resolve();
   }
 
@@ -361,4 +363,57 @@ export class Map3dSystem extends AbstractSystem {
       ],
     ];
   }
+  /**
+   * _hashchange
+   * Respond to any changes appearing in the url hash
+   * @param  currParams   Map(key -> value) of the current hash parameters
+   * @param  prevParams   Map(key -> value) of the previous hash parameters
+   */
+    // _hashchange(currParams, prevParams) {
+    //   // map3d
+    //   const newIds = currParams.get('map3d');
+    //   const oldIds = prevParams.get('map3d');
+    //   if (newIds !== oldIds) {
+    //     let shouldShow = context.systems.urlhash?.getParam('map3d');
+    //     let wrap = d3_select(null);
+
+    //     // context
+    //     //   .container()
+    //     //   .select('.three-d-map-toggle-item')
+    //     //   .classed('active', !_isHidden)
+    //     //   .select('input')
+    //     //   .property('checked', !_isHidden);
+  
+    //     if (shouldShow) {
+    //       wrap
+    //         .style('display', 'block')
+    //         .style('opacity', '1')
+    //         .transition()
+    //         .duration(200)
+    //         .style('opacity', '0')
+    //         .on('end', () =>
+    //           selection.selectAll('.three-d-map').style('display', 'none')
+    //         );
+    //       urlhash.setParam('map3d', null);
+    //       _isHidden = false;
+    //     } else {
+    //       wrap
+    //         .style('display', 'block')
+    //         .style('opacity', '0')
+    //         .transition()
+    //         .duration(200)
+    //         .style('opacity', '1')
+    //         .on('end', () => redraw());
+    //       urlhash.setParam('map3d', 'true');
+    //       _isHidden = true;
+    //     }
+    //     // if (typeof newIds === 'string') {
+    //     //   const ids = newIds.split(',').map(s => s.trim()).filter(Boolean);
+    //     //   const modeID = this.mode?.id;
+    //     //   if (ids.length && modeID !== 'save') {
+    //     //     this.selectEntityID(ids[0]);  // for now, just the select first one
+    //     //   }
+    //     // }
+    //   }
+    // }
 }

--- a/modules/core/Map3dSystem.js
+++ b/modules/core/Map3dSystem.js
@@ -21,7 +21,7 @@ export class Map3dSystem extends AbstractSystem {
     super(context);
     this.id = 'map3d';
     this.autoStart = false;
-    this.dependencies = new Set(['map']);
+    this.dependencies = new Set(['map', 'urlhash']);
     this.containerID = '3d-buildings';
     this.maplibre = null;
 

--- a/modules/core/Map3dSystem.js
+++ b/modules/core/Map3dSystem.js
@@ -28,7 +28,6 @@ export class Map3dSystem extends AbstractSystem {
     this._loadPromise = null;
     this._startPromise = null;
 
-    // this._hashchange = this._hashchange.bind(this);
     this.building3dlayerSpec = this.get3dBuildingLayerSpec('3D Buildings', 'osmbuildings');
     this.roadStrokelayerSpec = this.getRoadStrokeLayerSpec('Roads', 'osmroads');
     this.roadCasinglayerSpec = this.getRoadCasingLayerSpec('Roads', 'osmroads');
@@ -48,7 +47,6 @@ export class Map3dSystem extends AbstractSystem {
         return Promise.reject(`Cannot init:  ${this.id} requires ${id}`);
       }
     }
-    // context.systems.urlhash.on('hashchange', this._hashchange);
     return Promise.resolve();
   }
 
@@ -363,57 +361,4 @@ export class Map3dSystem extends AbstractSystem {
       ],
     ];
   }
-  /**
-   * _hashchange
-   * Respond to any changes appearing in the url hash
-   * @param  currParams   Map(key -> value) of the current hash parameters
-   * @param  prevParams   Map(key -> value) of the previous hash parameters
-   */
-    // _hashchange(currParams, prevParams) {
-    //   // map3d
-    //   const newIds = currParams.get('map3d');
-    //   const oldIds = prevParams.get('map3d');
-    //   if (newIds !== oldIds) {
-    //     let shouldShow = context.systems.urlhash?.getParam('map3d');
-    //     let wrap = d3_select(null);
-
-    //     // context
-    //     //   .container()
-    //     //   .select('.three-d-map-toggle-item')
-    //     //   .classed('active', !_isHidden)
-    //     //   .select('input')
-    //     //   .property('checked', !_isHidden);
-  
-    //     if (shouldShow) {
-    //       wrap
-    //         .style('display', 'block')
-    //         .style('opacity', '1')
-    //         .transition()
-    //         .duration(200)
-    //         .style('opacity', '0')
-    //         .on('end', () =>
-    //           selection.selectAll('.three-d-map').style('display', 'none')
-    //         );
-    //       urlhash.setParam('map3d', null);
-    //       _isHidden = false;
-    //     } else {
-    //       wrap
-    //         .style('display', 'block')
-    //         .style('opacity', '0')
-    //         .transition()
-    //         .duration(200)
-    //         .style('opacity', '1')
-    //         .on('end', () => redraw());
-    //       urlhash.setParam('map3d', 'true');
-    //       _isHidden = true;
-    //     }
-    //     // if (typeof newIds === 'string') {
-    //     //   const ids = newIds.split(',').map(s => s.trim()).filter(Boolean);
-    //     //   const modeID = this.mode?.id;
-    //     //   if (ids.length && modeID !== 'save') {
-    //     //     this.selectEntityID(ids[0]);  // for now, just the select first one
-    //     //   }
-    //     // }
-    //   }
-    // }
 }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -285,7 +285,7 @@ export function uiMap3dViewer(context) {
       // .classed('active', !_isHidden)
       // .select('input')
       // .property('checked', !_isHidden);
-      if(context.urlhash?.getParam('3d') === 'true'){
+      if(context.systems.urlhash?.getParam('3d') === 'true'){
         wrap
         .style('display', 'block')
         .style('opacity', '0')
@@ -298,7 +298,7 @@ export function uiMap3dViewer(context) {
           .style('display', 'block')
           .style('opacity', '1')
           .transition()
-          .duration(200)
+          .duration(0)
           .style('opacity', '0')
           .on('end', () =>
             selection.selectAll('.three-d-map').style('display', 'none')

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -226,6 +226,7 @@ export function uiMap3dViewer(context) {
       if (d3_event) d3_event.preventDefault();
 
       _isHidden = !_isHidden;
+      if(context.systems.urlhash?.getParam('map3d')) _isHidden = true;
 
       context
         .container()
@@ -234,7 +235,7 @@ export function uiMap3dViewer(context) {
         .select('input')
         .property('checked', !_isHidden);
 
-      if (_isHidden || context.systems.urlhash?.getParam('map3d') ) {
+      if (_isHidden ) {
         wrap
           .style('display', 'block')
           .style('opacity', '1')
@@ -281,6 +282,7 @@ export function uiMap3dViewer(context) {
    */
     function _hashchange(){
       if (context.systems.urlhash?.getParam('map3d')){
+        redraw()
         wrap
         .style('display', 'block')
         .style('opacity', '0')

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -243,6 +243,7 @@ export function uiMap3dViewer(context) {
           .on('end', () =>
             selection.selectAll('.three-d-map').style('display', 'none')
           );
+        urlhash.setParam('3d', true);
       } else {
         wrap
           .style('display', 'block')
@@ -251,7 +252,8 @@ export function uiMap3dViewer(context) {
           .duration(200)
           .style('opacity', '1')
           .on('end', () => redraw());
-      }
+          urlhash.setParam('3d', false);
+        }
     }
 
     /* setup */

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -260,7 +260,7 @@ export function uiMap3dViewer(context) {
 
     function _hashchange(){
       // _isHidden = !_isHidden;
-      let _isHidden = context.systems.urlhash?.getParam('map3d') ? true : false;
+      let _isHidden = context.systems.urlhash?.getParam('map3d');
 
       context
         .container()

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -23,7 +23,7 @@ export function uiMap3dViewer(context) {
 
 
     function redraw() {
-      if (_isHidden || context.systems.urlhash?.getParam('map3d')) return;
+      if (_isHidden && !context.systems.urlhash?.getParam('map3d')) return;
       updateProjection();
       featuresToGeoJSON();
     }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -19,8 +19,8 @@ export function uiMap3dViewer(context) {
 
   function render(selection) {
     let wrap = d3_select(null);
-    // let _isHidden = !context.systems.urlhash?.getParam('map3d'); // depends on URL hash
-    let _isHidden = true; // start as hidden
+    let _isHidden = !urlhash.getParam('map3d'); // depends on URL hash
+    // let _isHidden = true; // start as hidden
 
 
     function redraw() {
@@ -226,7 +226,7 @@ export function uiMap3dViewer(context) {
     function toggle(d3_event) {
       if (d3_event) d3_event.preventDefault();
 
-      let shouldShow = context.systems.urlhash?.getParam('map3d');
+      _isHidden = urlhash.getParam('map3d');
 
       context
         .container()
@@ -235,8 +235,7 @@ export function uiMap3dViewer(context) {
         .select('input')
         .property('checked', !_isHidden);
 
-      if (shouldShow) {
-        _isHidden = false;
+      if (_isHidden) {
         wrap
           .style('display', 'block')
           .style('opacity', '1')
@@ -248,7 +247,6 @@ export function uiMap3dViewer(context) {
           );
         urlhash.setParam('map3d', null);
       } else {
-        _isHidden = true;
         wrap
           .style('display', 'block')
           .style('opacity', '0')

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -258,12 +258,10 @@ export function uiMap3dViewer(context) {
         }
     }
 
-  /**
-   * _hashchange
-   * Respond to any changes appearing in the url hash
-   */
     function _hashchange(){
-      if (context.systems.urlhash?.getParam('map3d')){
+      let _isHidden = context.systems.urlhash?.getParam('map3d') ? true : false;
+
+      if (_isHidden){
         wrap
         .style('display', 'block')
         .style('opacity', '0')
@@ -299,11 +297,10 @@ export function uiMap3dViewer(context) {
     wrap = wrapEnter.merge(wrap);
     map3d.startAsync();
 
-    urlhash.on('hashchange', _hashchange);
     map.on('draw', () => redraw());
     map.on('move', () => redraw());
     context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
-
+    urlhash.on('hashchange', _hashchange);
 
     redraw();
   }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -37,7 +37,7 @@ export function uiMap3dViewer(context) {
       const center = extent.center();
       extent.padByMeters(100);
 
-      map3d.maplibre.jumpTo({
+      map3d.maplibre?.jumpTo({
         center: center,
         bearing: 0,
         zoom: map.zoom() - 3,

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -15,6 +15,7 @@ export function uiMap3dViewer(context) {
   const l10n = context.systems.l10n;
   const map = context.systems.map;
   const map3d = context.systems.map3d;
+  const urlhash = context.systems.urlhash;
 
   function render(selection) {
     let wrap = d3_select(null);
@@ -222,7 +223,6 @@ export function uiMap3dViewer(context) {
 
 
     function toggle(d3_event) {
-      const urlhash = context.systems.urlhash;
       if (d3_event) d3_event.preventDefault();
 
       _isHidden = !_isHidden;
@@ -275,6 +275,10 @@ export function uiMap3dViewer(context) {
     map.on('draw', () => redraw());
     map.on('move', () => redraw());
     context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
+    // if(context.urlhash.getParam('3d') === 'true'){
+    //   toggle();
+    // }
+    context.map.getp
 
     redraw();
   }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -275,16 +275,11 @@ export function uiMap3dViewer(context) {
     map.on('draw', () => redraw());
     map.on('move', () => redraw());
     context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
-    function _hashchange(currParams, prevParams){
-      const newMap = currParams.get('map');
-      const oldMap = prevParams.get('map');
-      // if (d3_event) d3_event.preventDefault();
-      // context
-      // .container()
-      // .select('.three-d-map-toggle-item')
-      // .classed('active', !_isHidden)
-      // .select('input')
-      // .property('checked', !_isHidden);
+  /**
+   * _hashchange
+   * Respond to any changes appearing in the url hash
+   */
+    function _hashchange(){
       if(context.systems.urlhash?.getParam('3d') === 'true'){
         wrap
         .style('display', 'block')

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -226,7 +226,7 @@ export function uiMap3dViewer(context) {
       if (d3_event) d3_event.preventDefault();
 
       _isHidden = !_isHidden;
-      if(context.systems.urlhash?.getParam('map3d')) _isHidden = true;
+      if (context.systems.urlhash?.getParam('map3d')) _isHidden = true;
 
       context
         .container()
@@ -258,31 +258,12 @@ export function uiMap3dViewer(context) {
         }
     }
 
-    /* setup */
-    uiMap3dViewer.toggle = toggle;
-
-    wrap = selection.selectAll('.three-d-map').data([0]);
-
-    let wrapEnter = wrap
-      .enter()
-      .append('div')
-      .attr('class', 'three-d-map')
-      .attr('id', '3d-buildings')
-      .style('display', _isHidden ? 'none' : 'block');
-
-    wrap = wrapEnter.merge(wrap);
-    map3d.startAsync();
-
-    map.on('draw', () => redraw());
-    map.on('move', () => redraw());
-    context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
   /**
    * _hashchange
    * Respond to any changes appearing in the url hash
    */
     function _hashchange(){
       if (context.systems.urlhash?.getParam('map3d')){
-        redraw()
         wrap
         .style('display', 'block')
         .style('opacity', '0')
@@ -302,7 +283,26 @@ export function uiMap3dViewer(context) {
           );
       }
     }
-    urlhash.on('hashchange', _hashchange );
+
+    /* setup */
+    uiMap3dViewer.toggle = toggle;
+
+    wrap = selection.selectAll('.three-d-map').data([0]);
+
+    let wrapEnter = wrap
+      .enter()
+      .append('div')
+      .attr('class', 'three-d-map')
+      .attr('id', '3d-buildings')
+      .style('display', _isHidden ? 'none' : 'block');
+
+    wrap = wrapEnter.merge(wrap);
+    map3d.startAsync();
+
+    urlhash.on('hashchange', _hashchange);
+    map.on('draw', () => redraw());
+    map.on('move', () => redraw());
+    context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
 
 
     redraw();

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -19,11 +19,11 @@ export function uiMap3dViewer(context) {
 
   function render(selection) {
     let wrap = d3_select(null);
-    let _isHidden = true; // start out hidden
+    let _isHidden = !context.systems.urlhash?.getParam('map3d'); // depends on URL hash
 
 
     function redraw() {
-      if (_isHidden && !context.systems.urlhash?.getParam('map3d')) return;
+      if (_isHidden) return;
       updateProjection();
       featuresToGeoJSON();
     }
@@ -225,8 +225,7 @@ export function uiMap3dViewer(context) {
     function toggle(d3_event) {
       if (d3_event) d3_event.preventDefault();
 
-      _isHidden = !_isHidden;
-      if (context.systems.urlhash?.getParam('map3d')) _isHidden = true;
+      let shouldShow = context.systems.urlhash?.getParam('map3d');
 
       context
         .container()
@@ -235,7 +234,7 @@ export function uiMap3dViewer(context) {
         .select('input')
         .property('checked', !_isHidden);
 
-      if (_isHidden ) {
+      if (shouldShow) {
         wrap
           .style('display', 'block')
           .style('opacity', '1')
@@ -246,7 +245,9 @@ export function uiMap3dViewer(context) {
             selection.selectAll('.three-d-map').style('display', 'none')
           );
         urlhash.setParam('map3d', null);
+        _isHidden = false;
       } else {
+        _isHidden = true;
         wrap
           .style('display', 'block')
           .style('opacity', '0')
@@ -255,40 +256,41 @@ export function uiMap3dViewer(context) {
           .style('opacity', '1')
           .on('end', () => redraw());
         urlhash.setParam('map3d', 'true');
-        }
-    }
-
-    function _hashchange(){
-      // _isHidden = !_isHidden;
-      let _isHidden = context.systems.urlhash?.getParam('map3d');
-
-      context
-        .container()
-        .select('.three-d-map-toggle-item')
-        .classed('active', !_isHidden)
-        .select('input')
-        .property('checked', !_isHidden);
-
-      if (_isHidden){
-        wrap
-        .style('display', 'block')
-        .style('opacity', '0')
-        .transition()
-        .duration(200)
-        .style('opacity', '1')
-        .on('end', () => redraw());
-      } else {
-        wrap
-          .style('display', 'block')
-          .style('opacity', '1')
-          .transition()
-          .duration(0)
-          .style('opacity', '0')
-          .on('end', () =>
-            selection.selectAll('.three-d-map').style('display', 'none')
-          );
+        _isHidden = false;
       }
     }
+
+    // function _hashchange(){
+    //   // _isHidden = !_isHidden;
+    //   let _isHidden = context.systems.urlhash?.getParam('map3d');
+
+    //   context
+    //     .container()
+    //     .select('.three-d-map-toggle-item')
+    //     .classed('active', !_isHidden)
+    //     .select('input')
+    //     .property('checked', !_isHidden);
+
+    //   if (_isHidden){
+    //     wrap
+    //     .style('display', 'block')
+    //     .style('opacity', '0')
+    //     .transition()
+    //     .duration(200)
+    //     .style('opacity', '1')
+    //     .on('end', () => redraw());
+    //   } else {
+    //     wrap
+    //       .style('display', 'block')
+    //       .style('opacity', '1')
+    //       .transition()
+    //       .duration(0)
+    //       .style('opacity', '0')
+    //       .on('end', () =>
+    //         selection.selectAll('.three-d-map').style('display', 'none')
+    //       );
+    //   }
+    // }
 
     /* setup */
     uiMap3dViewer.toggle = toggle;
@@ -308,7 +310,7 @@ export function uiMap3dViewer(context) {
     map.on('draw', () => redraw());
     map.on('move', () => redraw());
     context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
-    urlhash.on('hashchange', _hashchange);
+    urlhash.on('hashchange', toggle);
 
     redraw();
   }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -15,7 +15,7 @@ export function uiMap3dViewer(context) {
   const l10n = context.systems.l10n;
   const map = context.systems.map;
   const map3d = context.systems.map3d;
-  // const urlhash = context.systems.urlhash;
+  const urlhash = context.systems.urlhash;
 
   function render(selection) {
     let wrap = d3_select(null);
@@ -244,7 +244,7 @@ export function uiMap3dViewer(context) {
           .on('end', () =>
             selection.selectAll('.three-d-map').style('display', 'none')
           );
-        // urlhash.setParam('3d', null);
+        urlhash.setParam('3d', null);
       } else {
         wrap
           .style('display', 'block')
@@ -253,7 +253,7 @@ export function uiMap3dViewer(context) {
           .duration(200)
           .style('opacity', '1')
           .on('end', () => redraw());
-          // urlhash.setParam('3d', "true");
+        urlhash.setParam('3d', "true");
         }
     }
 
@@ -275,10 +275,38 @@ export function uiMap3dViewer(context) {
     map.on('draw', () => redraw());
     map.on('move', () => redraw());
     context.keybinding().on([uiCmd('⌘' + l10n.t('background.3dmap.key'))], toggle);
-    // if(context.urlhash.getParam('3d') === 'true'){
-    //   toggle();
-    // }
-    context.map.getp
+    function _hashchange(currParams, prevParams){
+      const newMap = currParams.get('map');
+      const oldMap = prevParams.get('map');
+      // if (d3_event) d3_event.preventDefault();
+      // context
+      // .container()
+      // .select('.three-d-map-toggle-item')
+      // .classed('active', !_isHidden)
+      // .select('input')
+      // .property('checked', !_isHidden);
+      if(context.urlhash?.getParam('3d') === 'true'){
+        wrap
+        .style('display', 'block')
+        .style('opacity', '0')
+        .transition()
+        .duration(200)
+        .style('opacity', '1')
+        .on('end', () => redraw());
+      } else {
+        wrap
+          .style('display', 'block')
+          .style('opacity', '1')
+          .transition()
+          .duration(200)
+          .style('opacity', '0')
+          .on('end', () =>
+            selection.selectAll('.three-d-map').style('display', 'none')
+          );
+      }
+    }
+    urlhash.on('hashchange', _hashchange );
+
 
     redraw();
   }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -23,7 +23,7 @@ export function uiMap3dViewer(context) {
 
 
     function redraw() {
-      if (_isHidden) return;
+      if (_isHidden || context.systems.urlhash?.getParam('map3d')) return;
       updateProjection();
       featuresToGeoJSON();
     }

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -19,7 +19,8 @@ export function uiMap3dViewer(context) {
 
   function render(selection) {
     let wrap = d3_select(null);
-    let _isHidden = !context.systems.urlhash?.getParam('map3d'); // depends on URL hash
+    // let _isHidden = !context.systems.urlhash?.getParam('map3d'); // depends on URL hash
+    let _isHidden = true; // start as hidden
 
 
     function redraw() {
@@ -235,6 +236,7 @@ export function uiMap3dViewer(context) {
         .property('checked', !_isHidden);
 
       if (shouldShow) {
+        _isHidden = false;
         wrap
           .style('display', 'block')
           .style('opacity', '1')
@@ -245,8 +247,8 @@ export function uiMap3dViewer(context) {
             selection.selectAll('.three-d-map').style('display', 'none')
           );
         urlhash.setParam('map3d', null);
-        _isHidden = false;
       } else {
+        _isHidden = true;
         wrap
           .style('display', 'block')
           .style('opacity', '0')
@@ -255,7 +257,6 @@ export function uiMap3dViewer(context) {
           .style('opacity', '1')
           .on('end', () => redraw());
         urlhash.setParam('map3d', 'true');
-        _isHidden = true;
       }
     }
 

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -253,7 +253,7 @@ export function uiMap3dViewer(context) {
           .duration(200)
           .style('opacity', '1')
           .on('end', () => redraw());
-        urlhash.setParam('3d', "true");
+        urlhash.setParam('3d', 'true');
         }
     }
 
@@ -280,7 +280,7 @@ export function uiMap3dViewer(context) {
    * Respond to any changes appearing in the url hash
    */
     function _hashchange(){
-      if(context.systems.urlhash?.getParam('3d') === 'true'){
+      if (context.systems.urlhash?.getParam('3d') === 'true'){
         wrap
         .style('display', 'block')
         .style('opacity', '0')

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -222,6 +222,7 @@ export function uiMap3dViewer(context) {
 
 
     function toggle(d3_event) {
+      const urlhash = context.systems.urlhash;
       if (d3_event) d3_event.preventDefault();
 
       _isHidden = !_isHidden;
@@ -243,7 +244,7 @@ export function uiMap3dViewer(context) {
           .on('end', () =>
             selection.selectAll('.three-d-map').style('display', 'none')
           );
-        urlhash.setParam('3d', true);
+        urlhash.setParam('3d', null);
       } else {
         wrap
           .style('display', 'block')
@@ -252,7 +253,7 @@ export function uiMap3dViewer(context) {
           .duration(200)
           .style('opacity', '1')
           .on('end', () => redraw());
-          urlhash.setParam('3d', false);
+          urlhash.setParam('3d', "true");
         }
     }
 

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -259,7 +259,15 @@ export function uiMap3dViewer(context) {
     }
 
     function _hashchange(){
+      // _isHidden = !_isHidden;
       let _isHidden = context.systems.urlhash?.getParam('map3d') ? true : false;
+
+      context
+        .container()
+        .select('.three-d-map-toggle-item')
+        .classed('active', !_isHidden)
+        .select('input')
+        .property('checked', !_isHidden);
 
       if (_isHidden){
         wrap

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -247,7 +247,6 @@ export function uiMap3dViewer(context) {
         urlhash.setParam('map3d', null);
         _isHidden = false;
       } else {
-        _isHidden = true;
         wrap
           .style('display', 'block')
           .style('opacity', '0')
@@ -256,7 +255,7 @@ export function uiMap3dViewer(context) {
           .style('opacity', '1')
           .on('end', () => redraw());
         urlhash.setParam('map3d', 'true');
-        _isHidden = false;
+        _isHidden = true;
       }
     }
 

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -15,7 +15,7 @@ export function uiMap3dViewer(context) {
   const l10n = context.systems.l10n;
   const map = context.systems.map;
   const map3d = context.systems.map3d;
-  const urlhash = context.systems.urlhash;
+  // const urlhash = context.systems.urlhash;
 
   function render(selection) {
     let wrap = d3_select(null);
@@ -244,7 +244,7 @@ export function uiMap3dViewer(context) {
           .on('end', () =>
             selection.selectAll('.three-d-map').style('display', 'none')
           );
-        urlhash.setParam('3d', null);
+        // urlhash.setParam('3d', null);
       } else {
         wrap
           .style('display', 'block')
@@ -253,7 +253,7 @@ export function uiMap3dViewer(context) {
           .duration(200)
           .style('opacity', '1')
           .on('end', () => redraw());
-          urlhash.setParam('3d', "true");
+          // urlhash.setParam('3d', "true");
         }
     }
 

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -234,7 +234,7 @@ export function uiMap3dViewer(context) {
         .select('input')
         .property('checked', !_isHidden);
 
-      if (_isHidden) {
+      if (_isHidden || context.systems.urlhash?.getParam('map3d') ) {
         wrap
           .style('display', 'block')
           .style('opacity', '1')
@@ -244,7 +244,7 @@ export function uiMap3dViewer(context) {
           .on('end', () =>
             selection.selectAll('.three-d-map').style('display', 'none')
           );
-        urlhash.setParam('3d', null);
+        urlhash.setParam('map3d', null);
       } else {
         wrap
           .style('display', 'block')
@@ -253,7 +253,7 @@ export function uiMap3dViewer(context) {
           .duration(200)
           .style('opacity', '1')
           .on('end', () => redraw());
-        urlhash.setParam('3d', 'true');
+        urlhash.setParam('map3d', 'true');
         }
     }
 
@@ -280,7 +280,7 @@ export function uiMap3dViewer(context) {
    * Respond to any changes appearing in the url hash
    */
     function _hashchange(){
-      if (context.systems.urlhash?.getParam('3d') === 'true'){
+      if (context.systems.urlhash?.getParam('map3d')){
         wrap
         .style('display', 'block')
         .style('opacity', '0')

--- a/modules/ui/map3d_viewer.js
+++ b/modules/ui/map3d_viewer.js
@@ -224,6 +224,7 @@ export function uiMap3dViewer(context) {
 
 
     function toggle(d3_event) {
+      if (!d3_event?.preventDefault) return;
       if (d3_event) d3_event.preventDefault();
 
       _isHidden = urlhash.getParam('map3d');
@@ -258,38 +259,6 @@ export function uiMap3dViewer(context) {
       }
     }
 
-    // function _hashchange(){
-    //   // _isHidden = !_isHidden;
-    //   let _isHidden = context.systems.urlhash?.getParam('map3d');
-
-    //   context
-    //     .container()
-    //     .select('.three-d-map-toggle-item')
-    //     .classed('active', !_isHidden)
-    //     .select('input')
-    //     .property('checked', !_isHidden);
-
-    //   if (_isHidden){
-    //     wrap
-    //     .style('display', 'block')
-    //     .style('opacity', '0')
-    //     .transition()
-    //     .duration(200)
-    //     .style('opacity', '1')
-    //     .on('end', () => redraw());
-    //   } else {
-    //     wrap
-    //       .style('display', 'block')
-    //       .style('opacity', '1')
-    //       .transition()
-    //       .duration(0)
-    //       .style('opacity', '0')
-    //       .on('end', () =>
-    //         selection.selectAll('.three-d-map').style('display', 'none')
-    //       );
-    //   }
-    // }
-
     /* setup */
     uiMap3dViewer.toggle = toggle;
 
@@ -315,4 +284,3 @@ export function uiMap3dViewer(context) {
 
   return render;
 }
-


### PR DESCRIPTION
## Description

Toggling the 3d map will now cause the URL to display the "3d=true" attribute.

Also, a URL with the 3d=true attribute will show the 3D map when the UI loads.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

https://github.com/facebook/Rapid/issues/1068

## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/facebook/Rapid/assets/2739245/9b5815e0-1978-4bbe-9b3b-b862fa8a6905)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [x] 📓 docs
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://archinect.imgix.net/uploads/ii/ii5hjppdm3e3hejj.gif)

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Rapid Contributing Guide: https://github.com/facebook/Rapid/blob/main/CONTRIBUTING.md.
  - 📖 Read the Rapid Code of Conduct: https://github.com/facebook/Rapid/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
