### PR TITLE
Ambiguous crossing validation

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1831,10 +1831,13 @@ en:
         reference: Intersecting highways should share a junction vertex.
     ambiguous_crossing_tags:
       title: Ambiguous Crossing Tags
-      message: "{feature} crossing info conflicts with {feature2}"
-      incomplete_message: "{feature} has crossing info, but one or more of its nodes does not."
-      tip: "Crossing way markings conflict with crossing nodes"
-      reference: Crossing way markings should not conflict with its crossing node.
+      message: "{feature} line info conflicts with point {feature2}"
+      message_markings: "{feature} marking info conflicts with point {feature2}"
+      incomplete_message: "{feature} has crossing info, but one or more of its points does not."
+      tip: "Crossing line markings conflict with crossing point"
+      reference: Crossing line markings should not conflict with its crossing point.
+      upgrade_node: "Upgrade node to:"
+      upgrade_way: "Upgrade way to:"
     area_as_point:
       message: '{feature} should be an area, not a point'
     close_nodes:
@@ -2048,12 +2051,13 @@ en:
         annotation: Added a tunnel.
       address_the_concern:
         title: Address the concern
-      use_crossing_tags_from_node:
-        title: Use the crossing node's tags
-        annotation: Updated parent way's crossing tag info from a node.
-      use_crossing_tags_from_way:
-        title: Use the crossing way's tags
-        annotation: Updated child node's crossing tag info from a parent way.
+      set_both_as_marked:
+        title: Set way and node to marked
+        title_use_marking: Set way and node to {marking} marking
+        annotation: set way and node to have crossing markings.
+      set_both_as_unmarked:
+        title: Set way and node to unmarked
+        annotation: set way and node to have no crossing markings.
       connect_almost_junction:
         annotation: Connected very close features.
       connect_crossing_features:

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2053,7 +2053,8 @@ en:
         title: Address the concern
       set_both_as_marked:
         title: Set way and node to marked
-        title_use_marking: Set way and node to {marking} marking
+        title_use_marking: Use '{marking}' marking
+        title_use_crossing: Use '{crossing}'
         annotation: set way and node to have crossing markings.
       set_both_as_unmarked:
         title: Set way and node to unmarked

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1831,12 +1831,13 @@ en:
         reference: Intersecting highways should share a junction vertex.
     ambiguous_crossing_tags:
       title: Ambiguous Crossing Tags
-      message: "{feature} line info conflicts with point {feature2}"
-      message_markings: "{feature} marking info conflicts with point {feature2}"
-      incomplete_message: "{feature} has crossing info, but one or more of its points does not."
+      message: "Line and point disagree about markings"
+      message_markings: "Line has marking '{marking1}' but point has marking '{marking2}'"
+      incomplete_message: "Point may be missing crossing information."
+      incomplete_reference: "Point looks like it may be updated to a crossing."
       tip: "Crossing line markings conflict with crossing point"
-      reference: Crossing line markings should not conflict with its crossing point.
-      upgrade_node: "Upgrade node to:"
+      reference: Line and point must either be both marked or both unmarked.
+      upgrade_node: "Upgrade point to:"
       upgrade_way: "Upgrade way to:"
     area_as_point:
       message: '{feature} should be an area, not a point'
@@ -2051,14 +2052,17 @@ en:
         annotation: Added a tunnel.
       address_the_concern:
         title: Address the concern
+      make_crossing_node:
+        title: Make point into a crossing
+        annotation: Make point into a crossing.
       set_both_as_marked:
-        title: Set way and node to marked
+        title: Set line and point to marked
         title_use_marking: Use '{marking}' marking
         title_use_crossing: Use '{crossing}'
-        annotation: set way and node to have crossing markings.
+        annotation: Set way and node to have crossing markings.
       set_both_as_unmarked:
-        title: Set way and node to unmarked
-        annotation: set way and node to have no crossing markings.
+        title: Set line and point to unmarked
+        annotation: Set way and node to have no crossing markings.
       connect_almost_junction:
         annotation: Connected very close features.
       connect_crossing_features:

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -259,8 +259,11 @@ export function validationAmbiguousCrossingTags(context) {
       let fixes = [];
       const graph = editor.staging.graph;
 
-      const parentWay = graph.hasEntity(this.entityIds[1]);
-      const node = graph.hasEntity(this.entityIds[0]);
+      const [nodeID, wayID] = this.entityIds;
+      const parentWay = graph.hasEntity(wayID);
+      const node = graph.hasEntity(nodeID);
+
+      if (!parentWay || !node) return;
 
       // Only display this fix if the node markings are present
       if (node.tags['crossing:markings']) {
@@ -322,7 +325,10 @@ export function validationAmbiguousCrossingTags(context) {
     function makeMarkedUnmarkedFixes() {
       let fixes = [];
       const graph = editor.staging.graph;  // I think we use staging graph for dynamic fixes?
-      const parentWay = graph.hasEntity(this.entityIds[1]);
+      const [nodeID, wayID] = this.entityIds;
+      const node = graph.hasEntity(nodeID);
+      const parentWay = graph.hasEntity(wayID);
+      if (!node || !parentWay) return;
 
       if (parentWay) {
         fixes.push(
@@ -452,8 +458,12 @@ export function validationAmbiguousCrossingTags(context) {
 
     function makeCandidateFixes() {
       let fixes = [];
+      const graph = editor.staging.graph;
+      const [nodeID, wayID] = this.entityIds;
+      const node = graph.hasEntity(nodeID);
+      const way = graph.hasEntity(wayID);
+      if (!node || !way) return;
 
-      const way = currentNodeInfo.way;
 
       fixes.push(
         new ValidationFix({

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -301,7 +301,7 @@ export function validationAmbiguousCrossingTags(context) {
             title: l10n.tHtml('issues.fix.set_both_as_unmarked.title'),
             onClick: function () {
 
-              const annotation = l10n.t('issues.fix.use_crossing_tags_from_node.annotation');
+              const annotation = l10n.t('issues.fix.set_both_as_unmarked.annotation');
               editor.perform(actionChangeTags(currentInfo.node.id, nodeDowngradeTags));
               editor.perform(actionChangeTags(currentInfo.way.id, wayDowngradeTags));
               editor.commit({ annotation: annotation, selectedIDs: context.selectedIDs() });
@@ -409,7 +409,7 @@ export function validationAmbiguousCrossingTags(context) {
       fixes.push(
         new ValidationFix({
           icon: 'rapid-icon-crossing',
-          title: l10n.tHtml('issues.fix.use_crossing_tags_from_way.title'),
+          title: l10n.tHtml('issues.fix.set_both_as_marked.title'),
           onClick: function () {
             const graph = editor.staging.graph;
             const [nodeID, wayID] = this.issue.entityIds;
@@ -418,7 +418,7 @@ export function validationAmbiguousCrossingTags(context) {
             if (!node || !way) return;
 
             const wayTags = way.tags;
-            let tags = {};
+            let tags = Object.assign({}, node.tags);
 
             // At the very least, we need to make the node into a crossing node
             tags.highway = 'crossing';
@@ -430,12 +430,15 @@ export function validationAmbiguousCrossingTags(context) {
             }
             tags.highway = 'crossing';
 
-            const annotation = l10n.t('issues.fix.use_crossing_tags_from_way.annotation');
+
+            const annotation = l10n.t('issues.fix.set_both_as_marked.annotation');
             editor.perform(actionChangeTags(nodeID, tags));
             editor.commit({ annotation: annotation, selectedIDs: context.selectedIDs() });
           }
         })
       );
+
+      return fixes;
     }
 
 

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -19,7 +19,7 @@ export function validationAmbiguousCrossingTags(context) {
   }
 
   function isCrossingNode(node) {
-    return node.tags.crossing;
+    return node.tags.crossing || node.tags.highway === 'crossing';
   }
 
 
@@ -61,13 +61,11 @@ export function validationAmbiguousCrossingTags(context) {
         //Check to see if the parent way / child node crossing tags conflict.
 
         // Marked/unmarked abmiguities/conflicts:
-        //Marked node with explicitly unmarked way
-        //marked node with unannotated way
-        //Marked way with explicitly unmarked node
-        //Marked way with unannotated node
-        //Generate 2 fixes: mark both as marked, or both as unmarked, optionally use marking value (if any)
-        if ((parentWay.tags?.crossing !== 'unmarked' && crossingNode.tags?.crossing === 'unmarked') ||
-          (parentWay.tags?.crossing !== 'marked' && crossingNode.tags?.crossing === 'marked')) {
+        // Marked way with explicitly unmarked or unannotated node
+        // Marked node with explicitly unmarked or unannotated way
+        // Generate 2 fixes: mark both as unmarked, or both as marked & optionally use marking value (if any)
+        if ((parentWay.tags?.crossing !== 'unmarked' && noCrossingMarkings(crossingNode.tags)) ||
+          (crossingNode.tags?.crossing !== 'unmarked' && noCrossingMarkings(parentWay.tags))) {
             markedUnmarkedConflicts.push({
             node: crossingNode,
             way: parentWay,
@@ -83,6 +81,10 @@ export function validationAmbiguousCrossingTags(context) {
         }
       });
     });
+
+    function noCrossingMarkings(nodeTags) {
+      return nodeTags?.crossing === 'unmarked' || !nodeTags?.crossing;
+    }
 
     markedUnmarkedConflicts.forEach(conflictingNodeInfo => {
       currentInfo = conflictingNodeInfo;

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -151,10 +151,7 @@ export function validationAmbiguousCrossingTags(context) {
           const graph = editor.staging.graph;
           const node = graph.hasEntity(this.entityIds[0]);
           const way = graph.hasEntity(this.entityIds[1]);
-          return (way && node) ? l10n.tHtml('issues.ambiguous_crossing_tags.message', {
-            feature:  l10n.displayLabel(node, graph),
-            feature2: l10n.displayLabel(way, graph)
-          }) : '';
+          return (way && node) ? l10n.tHtml('issues.ambiguous_crossing_tags.message') : '';
         },
         reference: showReference,
         entityIds: [ conflictingNodeInfo.node.id, conflictingNodeInfo.way.id ],
@@ -215,8 +212,8 @@ export function validationAmbiguousCrossingTags(context) {
           const node = graph.hasEntity(this.entityIds[0]);
           const way = graph.hasEntity(this.entityIds[1]);
           return l10n.tHtml('issues.ambiguous_crossing_tags.message_markings', {
-            feature: l10n.displayLabel(node, graph),
-            feature2: l10n.displayLabel(way, graph)
+            marking1: way.tags['crossing:markings'],
+            marking2: node.tags['crossing:markings']
           });
         },
         reference: showReference,
@@ -410,9 +407,7 @@ export function validationAmbiguousCrossingTags(context) {
         message: function () {
           const graph = editor.staging.graph;
           const way = graph.hasEntity(this.entityIds[1]);
-          return l10n.tHtml('issues.ambiguous_crossing_tags.incomplete_message', {
-            feature: l10n.displayLabel(way, graph)
-          });
+          return l10n.tHtml('issues.ambiguous_crossing_tags.incomplete_message');
         },
         reference: showReference,
         entityIds: [
@@ -468,9 +463,9 @@ export function validationAmbiguousCrossingTags(context) {
       fixes.push(
         new ValidationFix({
           icon: 'rapid-icon-crossing',
-          title: l10n.tHtml(hasMarkings(way) ? 'issues.fix.set_both_as_marked.title' : 'issues.fix.set_both_as_unmarked.title'),
+          title: l10n.tHtml('issues.fix.make_crossing_node.title'),
           onClick: function () {
-            const annotation = l10n.t(hasMarkings(way)  ? 'issues.fix.set_both_as_marked.annotation' : 'issues.fix.set_both_as_unmarked.annotation' );
+            const annotation = l10n.t('issues.fix.make_crossing_node.annotation');
             editor.perform(doTagUpgrade);
             editor.commit({ annotation: annotation, selectedIDs: context.selectedIDs() });
           }
@@ -506,7 +501,7 @@ export function validationAmbiguousCrossingTags(context) {
         .enter()
         .append('div')
         .attr('class', 'issue-reference')
-        .html(l10n.tHtml('issues.ambiguous_crossing_tags.reference'));
+        .html(l10n.tHtml('issues.ambiguous_crossing_tags.incomplete_reference'));
     }
   }
 

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -453,12 +453,14 @@ export function validationAmbiguousCrossingTags(context) {
     function makeCandidateFixes() {
       let fixes = [];
 
+      const way = currentNodeInfo.way;
+
       fixes.push(
         new ValidationFix({
           icon: 'rapid-icon-crossing',
-          title: l10n.tHtml('issues.fix.set_both_as_marked.title'),
+          title: l10n.tHtml(hasMarkings(way) ? 'issues.fix.set_both_as_marked.title' : 'issues.fix.set_both_as_unmarked.title'),
           onClick: function () {
-            const annotation = l10n.t('issues.fix.set_both_as_marked.annotation');
+            const annotation = l10n.t(hasMarkings(way)  ? 'issues.fix.set_both_as_marked.annotation' : 'issues.fix.set_both_as_unmarked.annotation' );
             editor.perform(doTagUpgrade);
             editor.commit({ annotation: annotation, selectedIDs: context.selectedIDs() });
           }

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -76,8 +76,8 @@ export function validationAmbiguousCrossingTags(context) {
         // Marked way with explicitly unmarked or unannotated node
         // Marked node with explicitly unmarked or unannotated way
         // Generate 2 fixes: mark both as unmarked, or both as marked & optionally use marking value (if any)
-        if ((parentWay.tags?.crossing !== 'unmarked' && noCrossingMarkings(crossingNode.tags)) ||
-          (crossingNode.tags?.crossing !== 'unmarked' && noCrossingMarkings(parentWay.tags))) {
+        if ((hasCrossingMarkings(parentWay.tags) && noCrossingMarkings(crossingNode.tags)) ||
+          (hasCrossingMarkings(crossingNode.tags) && noCrossingMarkings(parentWay.tags))) {
             markedUnmarkedConflicts.push({
             node: crossingNode,
             way: parentWay,
@@ -94,8 +94,13 @@ export function validationAmbiguousCrossingTags(context) {
       });
     });
 
-    function noCrossingMarkings(nodeTags) {
-      return nodeTags?.crossing === 'unmarked' || !nodeTags?.crossing;
+    function noCrossingMarkings(entityTags) {
+      const tag = entityTags?.crossing;
+      return  tag === 'unmarked' || tag === 'informal' || !tag;
+    }
+
+    function hasCrossingMarkings(entityTags) {
+      return entityTags?.crossing === 'uncontrolled' || entityTags?.crossing === 'marked';
     }
 
     // For each marked/unmarked conflict, we'll need to generate two fixes:

--- a/modules/validations/ambiguous_crossing_tags.js
+++ b/modules/validations/ambiguous_crossing_tags.js
@@ -172,6 +172,10 @@ export function validationAmbiguousCrossingTags(context) {
         wayUpdateTags['crossing:markings'] = nodeMarkingVal;
       }
 
+      //The autofix button can only do one thing- so we'll prefer to use the way tags over the node tags.
+      let autoArgs = [doMarkBothAsWay, l10n.t(wayMarkingVal ? 'issues.fix.set_both_as_marked.annotation' : 'issues.fix.set_both_as_unmarked.annotation')];
+
+
       issues.push(new ValidationIssue(context, {
         type,
         subtype: 'fixme_tag',
@@ -191,7 +195,8 @@ export function validationAmbiguousCrossingTags(context) {
           conflictingMarkingInfo.way.id,
         ],
         loc: conflictingMarkingInfo.node.loc,
-        hash:  utilHashcode(JSON.stringify(conflictingMarkingInfo.node.loc)),
+        hash: utilHashcode(JSON.stringify(conflictingMarkingInfo.node.loc)),
+        autoArgs: autoArgs,
         data: {
           wayTags: conflictingMarkingInfo.way.tags,
           nodeTags: conflictingMarkingInfo.node.tags
@@ -266,18 +271,19 @@ export function validationAmbiguousCrossingTags(context) {
       }
 
 
-      function doMarkBothAsNode() {
-        return actionChangeTags(currentInfo.way.id, wayUpdateTags)(graph);
-      }
-
-
-      function doMarkBothAsWay() {
-        return actionChangeTags(currentInfo.node.id, nodeUpdateTags)(graph);
-      }
-
       return fixes;
     }
 
+    function doMarkBothAsNode() {
+      return actionChangeTags(currentInfo.way.id, wayUpdateTags)(graph);
+    }
+
+
+    function doMarkBothAsWay() {
+      return actionChangeTags(currentInfo.node.id, nodeUpdateTags)(graph);
+    }
+
+    
     function makeFixes() {
       let fixes = [];
       const graph = editor.staging.graph;  // I think we use staging graph for dynamic fixes?

--- a/test/spec/validations/ambiguous_crossing_tags.js
+++ b/test/spec/validations/ambiguous_crossing_tags.js
@@ -73,7 +73,7 @@ describe('validationAmbiguousCrossingTags', () => {
   }
 
 
-  function verifySingleCrossingIssue(issues) {
+  function verifySingleCrossingWarning(issues) {
     // each entity must produce an identical issue
     expect(issues).to.have.lengthOf(1);
 
@@ -85,6 +85,21 @@ describe('validationAmbiguousCrossingTags', () => {
       expect(issue.loc).to.eql([0, 0]);
     }
   }
+
+
+  function verifySingleCrossingError(issues) {
+    // each entity must produce an identical issue
+    expect(issues).to.have.lengthOf(1);
+
+    for (const issue of issues) {
+      expect(issue.type).to.eql('ambiguous_crossing_tags');
+      expect(issue.severity).to.eql('error');
+
+      expect(issue.entityIds).to.have.lengthOf(2);
+      expect(issue.loc).to.eql([0, 0]);
+    }
+  }
+
 
   it('ignores untagged lines that share an untagged crossing node', () => {
     createWaysWithOneCrossingNode();
@@ -99,7 +114,7 @@ describe('validationAmbiguousCrossingTags', () => {
       { 'crossing:markings' : 'yes' }
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingWarning(issues);
   });
 
   it('flags unmarked lines that share a zebra-marked crossing node', () => {
@@ -109,7 +124,7 @@ describe('validationAmbiguousCrossingTags', () => {
       { MARKING_TAG: 'zebra' }
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingWarning(issues);
   });
 
   it('flags marked lines that share an unmarked crossing node', () => {
@@ -119,17 +134,17 @@ describe('validationAmbiguousCrossingTags', () => {
       { 'crossing:markings': 'no' }
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingWarning(issues);
   });
 
   it('flags marked lines and nodes that have a different crossing marking type', () => {
     createWaysWithOneCrossingNode(
       { crossing: 'marked', 'crossing:markings': 'zebra', highway: 'footway', footway: 'crossing' },
       { highway: 'residential' },
-      { 'crossing:markings': 'lines' }
+      { 'highway': 'crossing', 'crossing':'marked', 'crossing:markings': 'lines' }
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingError(issues);
   });
 
   it('flags an informal line and marked node', () => {
@@ -139,17 +154,17 @@ describe('validationAmbiguousCrossingTags', () => {
       { 'crossing:markings': 'lines' }
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingWarning(issues);
   });
 
   it('flags an marked line and informal ladder node', () => {
     createWaysWithOneCrossingNode(
       { crossing: 'marked', highway: 'footway', footway: 'crossing'},
       { highway: 'residential' },
-      { 'crossing:markings': 'ladder', 'crossing':'informal'}
+      { 'highway':'crossing', 'crossing':'informal'}
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingWarning(issues);
   });
 
   it('flags a marked line with potential unmarked crossing nodes', () => {
@@ -159,7 +174,7 @@ describe('validationAmbiguousCrossingTags', () => {
       {}
     );
     const issues = validate();
-    verifySingleCrossingIssue(issues);
+    verifySingleCrossingWarning(issues);
   });
 
 });

--- a/test/spec/validations/ambiguous_crossing_tags.js
+++ b/test/spec/validations/ambiguous_crossing_tags.js
@@ -157,7 +157,7 @@ describe('validationAmbiguousCrossingTags', () => {
     verifySingleCrossingWarning(issues);
   });
 
-  it('flags an marked line and informal ladder node', () => {
+  it('flags a marked line and informal ladder node', () => {
     createWaysWithOneCrossingNode(
       { crossing: 'marked', highway: 'footway', footway: 'crossing'},
       { highway: 'residential' },

--- a/test/spec/validations/ambiguous_crossing_tags.js
+++ b/test/spec/validations/ambiguous_crossing_tags.js
@@ -167,7 +167,7 @@ describe('validationAmbiguousCrossingTags', () => {
     verifySingleCrossingWarning(issues);
   });
 
-  it('flags a marked line with potential unmarked crossing nodes', () => {
+  it('flags a marked line with bare crossing candidate node', () => {
     createWaysWithOneCrossingNode(
       { crossing: 'marked', highway: 'footway', footway: 'crossing'},
       { highway: 'residential' },


### PR DESCRIPTION
## Description

This PR updates the already partially-landed ambiguous crossing tags check for the Validator, whose fix logic and strings were incomplete/incorrect.  This PR addresses two issues: #1141 and #1142. 

## Reference: 

Before diving in, have these two pages handy: 
[Crossings](https://wiki.openstreetmap.org/wiki/Crossings)
[Crossing:markings](https://wiki.openstreetmap.org/wiki/Key:crossing:markings)

This validation attempts to reconcile 'ambiguous' crosswalks and their crossing nodes. More on the checks below. 

## Definitions
Crosswalk: any OSM way with `highway=footway` and `footway=crossing`

Crossing node: Any OSM Node that is
1) Part of a crosswalk
2) has multiple parent ways
3) Is tagged with `highway=crossing`. 

## Background
I implemented parts of this check but the logic and wording was too complex, the existing code asked mappers to 'mark both like the way' or 'mark both like the node' but this required too much fiddling/mouse clicking to determine which fix to go with. As per @bhousel's suggestion I have instead gone with 'set both as ...' which is easier to understand just by glancing at the imagery. 

_Update: I have updated the screenshots to reflect the latest strings/text as per @bhousel's PR feedback_

 I have structured the code by splitting the ambiguous crossing checks into three 'sub-checks': 

1) 🚫  Error: Crossing nodes whose markings directly conflict with their parent crosswalk ways:

![image](https://github.com/facebook/Rapid/assets/1887955/b1c3bdd0-8a76-4936-86b7-89f68c96f2e3)

2) ⚠️ Warning: Either the crossing node or its parent is unmarked, yet the other is marked:

![image](https://github.com/facebook/Rapid/assets/1887955/6991fe67-f893-4fb9-a817-e0aafc3e3f85)

3) ⚠️ Warning: The crosswalk has multiple bare nodes that might need to be upgraded to crossings:

![image](https://github.com/facebook/Rapid/assets/1887955/0f92efc1-2c62-4782-814b-54b02ad3c97c)

in all cases where the fix is 'set as marked', we make an attempt to use the markings set on the marked entity (if any):

- If you click 'set as marked' to fix an issue between a marked node and unmarked crossing, both will get 'crossing:markings=yes'. 

- If you did the same on a marked node with `zebra` style markings, then the crosswalk would get those same markings as well instead of just `yes`. 

# Autofixes
In addition to the normal fixes, we have some auto-fixes that will help our power users to fix issues faster: These should be used with caution as the fixes simply short-circuit the 'set as marked' and 'set as unmarked' decision making to simply make both entities to have the markings of the crosswalk way. 

So, if you have a crosswalk with 'zebra' markings and an unmarked crossing node and are in power user mode, you will see: 

![image](https://github.com/facebook/Rapid/assets/1887955/2e6db7dc-969a-47db-87ca-d95e697131b3)

Clicking the wrench icon to fix the issue will replace the node markings with the way's markings. This might be odd for some folks since the two choices presented on the left are 'set as marked' and 'set as unmarked', but in the auto-fix we're doing 'just use whatever the way has' (I personally think this is okay, but just wanted to call it out).


Here's a short vid showing the power of these autofixes in a neighborhood whose crossing ways have the correct markings, but whose crossing nodes are `candidate` nodes that need updating. A single click can fix the issues: 

https://github.com/facebook/Rapid/assets/1887955/0db16817-f07f-4a91-a607-4aeb8fbcf8d9



## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Keep in mind that the tests we have for Validations are pretty bare-bones - we only test to ensure that a validation was generated and that the validator produced the correct 'type' and 'classification' of error (warning for two of the checks, error for the third). 

We do not test any of the potential fixes for the checks in the unit test code, mostly because how the code is structured is extremely brittle and depends a lot on closures.  This is part of the 
## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?
![image](https://github.com/facebook/Rapid/assets/1887955/46f2c5e6-a548-4bca-8777-8b12b9fac1b3)


<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Rapid Contributing Guide: https://github.com/facebook/Rapid/blob/main/CONTRIBUTING.md.
  - 📖 Read the Rapid Code of Conduct: https://github.com/facebook/Rapid/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
