### PR TITLE
Convert EditSystem `fromJSON` -> `fromJSONAsync`

### DIFF
--- a/modules/core/AbstractSystem.js
+++ b/modules/core/AbstractSystem.js
@@ -14,7 +14,7 @@ import { EventEmitter } from '@pixi/utils';
  *   At this stage all components are still being constructed, in no particular order.
  *   You should not call other components or use the context in the constructor.
  *
- * initAsync() - called one time after all systems are constructed.
+ * `initAsync()` - called one time after all systems are constructed.
  *   Systems may check at init time that their dependencies are met.
  *   They may chain onto other system initAsync promises in order to establish a dependency graph.
  *   (for example, if DataLoaderSystem must be initialized and ready
@@ -24,7 +24,7 @@ import { EventEmitter } from '@pixi/utils';
  *   You should be able to call methods but there is no user interface yet.
  *   and no events will be dispatched yet.
  *
- * startAsync() - called one time after all systems are initialized
+ * `startAsync()` - called one time after all systems are initialized
  *   At this stage we are creating the user interface and the map.
  *   There is an `autoStart` property that defaults to `true` but can be set `false` for some systems.
  *   (for example Map3dSystem doesn't need to load and start MapLibre until the user actually decides
@@ -32,13 +32,18 @@ import { EventEmitter } from '@pixi/utils';
  *   Like with init, components can chain onto other components startAsync promises they depend on.
  *   After 'start', the system should be doing its job and dispatching events.
  *
- * resetAsync() - called after completing an edit session to reset any internal state
+ * `resetAsync()` - called after completing an edit session to reset any internal state
  *   Resets mainly happen when completing an edit session, but can happen other times
  *   for example entering/exiting the tutorial or when switching connection between live/dev OSM API.
  *
+ * `pause()` / `resume()` - call these methods from other parts of the application to pause or resume.
+ *   The meaning of "pause" / "resume" is dependent on the system - they may not be used at all.
+ *   It may be used to prevent network fetches, background work, or rendering.
+ *   (Note: they are currently sync - may need to be made async in the future?)
+ *
  * Properties you can access:
  *   `id`        `String`   Identifier for the system (e.g. 'l10n')
- *   `autoStart` `Boolean`  True to start automatically when initializing the context
+ *   `autoStart` `Boolean`  True to start automatically when initializing the Context
  */
 export class AbstractSystem extends EventEmitter {
 
@@ -54,7 +59,9 @@ export class AbstractSystem extends EventEmitter {
     this.autoStart = true;
 
     this._started = false;
+    this._paused = false;
   }
+
 
   /**
    * started
@@ -62,6 +69,15 @@ export class AbstractSystem extends EventEmitter {
    */
   get started() {
     return this._started;
+  }
+
+
+  /**
+   * paused
+   * @readonly
+   */
+  get paused() {
+    return this._paused;
   }
 
 
@@ -98,6 +114,28 @@ export class AbstractSystem extends EventEmitter {
    */
   resetAsync() {
     return Promise.resolve();
+  }
+
+
+  /**
+   * pause
+   * Pauses this system
+   * The meaning of "pause" / "resume" is dependent on the system - they may not be used at all.
+   * It may be used to prevent network fetches, background work, or rendering.
+   */
+  pause() {
+    this._paused = true;
+  }
+
+
+  /**
+   * resume
+   * Resumes (unpauses) this system.
+   * The meaning of "pause" / "resume" is dependent on the system - they may not be used at all.
+   * It may be used to prevent network fetches, background work, or rendering.
+   */
+  resume() {
+    this._paused = false;
   }
 
 }

--- a/modules/core/AbstractSystem.js
+++ b/modules/core/AbstractSystem.js
@@ -10,33 +10,35 @@ import { EventEmitter } from '@pixi/utils';
  * System Components all go through a standard lifecycle.
  * `constructor()` -> `initAsync()` -> `startAsync()`
  *
- * `constructor()` - called one time and passed the Context.
+ * `constructor()` - Called one time and passed the Context.
  *   At this stage all components are still being constructed, in no particular order.
  *   You should not call other components or use the context in the constructor.
  *
- * `initAsync()` - called one time after all systems are constructed.
+ * `initAsync()` - Called one time after all systems are constructed.
  *   Systems may check at init time that their dependencies are met.
- *   They may chain onto other system initAsync promises in order to establish a dependency graph.
- *   (for example, if DataLoaderSystem must be initialized and ready
- *    so that the ImagerySystem can start fetching its imagery index)
- *   initAsync is also a good place to set up event listeners.
+ *   They may chain onto other system `initAsync` promises in order to establish a dependency graph.
+ *   (for example, if `DataLoaderSystem` must be initialized and ready
+ *    so that the `ImagerySystem` can start fetching its imagery index)
+ *   `initAsync` is also a good place to set up event listeners.
  *   After 'init', the component should mostly be able to function normally.
  *   You should be able to call methods but there is no user interface yet.
  *   and no events will be dispatched yet.
  *
- * `startAsync()` - called one time after all systems are initialized
+ * `startAsync()` - Called one time after all systems are initialized.
  *   At this stage we are creating the user interface and the map.
  *   There is an `autoStart` property that defaults to `true` but can be set `false` for some systems.
- *   (for example Map3dSystem doesn't need to load and start MapLibre until the user actually decides
- *    they want to see it - it is another component's job to call `startAsync() in this situation`)
+ *   (for example `Map3dSystem` doesn't need to load and start MapLibre until the user actually decides
+ *    they want to see it - it is another component's job to call `startAsync` in this situation)
  *   Like with init, components can chain onto other components startAsync promises they depend on.
  *   After 'start', the system should be doing its job and dispatching events.
  *
- * `resetAsync()` - called after completing an edit session to reset any internal state
- *   Resets mainly happen when completing an edit session, but can happen other times
- *   for example entering/exiting the tutorial or when switching connection between live/dev OSM API.
+ * `resetAsync()` - Called after completing an edit session to reset any internal state.
+ *   Resets mainly happen when completing an edit session, but can happen other times,
+ *   for example entering/exiting the tutorial, restoring a saved backup, or when switching
+ *   connection between live/dev OSM API.  Each system is responsible for clearing out any
+ *   stored state during reset.
  *
- * `pause()` / `resume()` - call these methods from other parts of the application to pause or resume.
+ * `pause()` / `resume()` - Call these methods from other parts of the application to pause or resume.
  *   The meaning of "pause" / "resume" is dependent on the system - they may not be used at all.
  *   It may be used to prevent network fetches, background work, or rendering.
  *   (Note: they are currently sync - may need to be made async in the future?)
@@ -109,7 +111,7 @@ export class AbstractSystem extends EventEmitter {
 
   /**
    * resetAsync
-   * Called after completing an edit session to reset any internal state
+   * Called after completing an edit session to reset any internal state.
    * @return {Promise} Promise resolved when this component has completed resetting
    */
   resetAsync() {

--- a/modules/core/EditSystem.js
+++ b/modules/core/EditSystem.js
@@ -1062,8 +1062,8 @@ export class EditSystem extends AbstractSystem {
 
     // Call _finish when we believe we have everything.
     const _finish = () => {
-      loading.close();            // unblock ui
-      map.redrawEnabled = true;   // unbock drawing
+      loading.close();         // unblock ui
+      map.resume();            // unbock drawing
       this._replaceStaging();
       this._updateChanges();
       this.emit('historyjump', 0, this._index);  // send 0 in prevIndex, we are replacing history completely
@@ -1093,7 +1093,7 @@ export class EditSystem extends AbstractSystem {
       }
 
       if (missingIDs.size) {
-        map.redrawEnabled = false;           // block drawing
+        map.pause();                         // block drawing
         context.container().call(loading);   // block ui
 
         // watch out: this callback may be called multiple times..

--- a/modules/core/MapSystem.js
+++ b/modules/core/MapSystem.js
@@ -20,15 +20,15 @@ function clamp(num, min, max) {
 
 
 /**
- * `MapSystem` maintains the map state
- * and provides an interface for manipulating the map view.
+ * `MapSystem` maintains the map state and provides an interface for manipulating the map view.
+ *
+ * Supports `pause()` / `resume()` - when paused, the map system will not render
  *
  * Properties available:
  *   `dimensions`      The pixel dimensions of the map viewport [width,height]
  *   `supersurface`    D3 selection to the parent `div` "supersurface"
  *   `surface`         D3 selection to the sibling `canvas` "surface"
  *   `overlay`         D3 selection to the sibling `div` "overlay"
- *   `redrawEnabled`   `true` to allow drawing, `false` to pause drawing
  *   `highlightEdits`   true` if edited features should be shown in a special style, `false` otherwise
  *   `areaFillMode`    one of 'full', 'partial' (default), or 'wireframe'
  *   `wireframeMode`   `true` if fill mode is 'wireframe', `false` otherwise
@@ -53,7 +53,6 @@ export class MapSystem extends AbstractSystem {
     this.supersurface = d3_select(null);  // parent `div` temporary zoom/pan transform
     this.surface = d3_select(null);       // sibling `canvas`
     this.overlay = d3_select(null);       // sibling `div`, offsets supersurface transform (used to hold the editmenu)
-    this.redrawEnabled = true;
 
     // display options
     this.areaFillOptions = ['wireframe', 'partial', 'full'];
@@ -169,7 +168,7 @@ export class MapSystem extends AbstractSystem {
     selection
       // Suppress the native right-click context menu
       .on('contextmenu', e => e.preventDefault())
-      // Suppress swipe-to-navigate browser pages on trackpad/magic mouse – #5552
+      // Suppress swipe-to-navigate browser pages on trackpad/magic mouse – iD#5552
       .on('wheel.map mousewheel.map', e => e.preventDefault());
 
     // The `supersurface` is a wrapper div that we temporarily transform as the user zooms and pans.
@@ -365,7 +364,7 @@ export class MapSystem extends AbstractSystem {
    * allow the changes to batch up over several animation frames.
    */
   deferredRedraw() {
-    if (!this._renderer || !this.redrawEnabled) return;
+    if (!this._renderer || this._paused) return;
     this._renderer.deferredRender();
   }
 
@@ -377,7 +376,7 @@ export class MapSystem extends AbstractSystem {
    * the map to update on one of the next few animation frames to show their change.
    */
   immediateRedraw() {
-    if (!this._renderer || !this.redrawEnabled) return;
+    if (!this._renderer || this._paused) return;
     this._renderer.render();
   }
 

--- a/modules/core/MapSystem.js
+++ b/modules/core/MapSystem.js
@@ -22,7 +22,7 @@ function clamp(num, min, max) {
 /**
  * `MapSystem` maintains the map state and provides an interface for manipulating the map view.
  *
- * Supports `pause()` / `resume()` - when paused, the map system will not render
+ * Supports `pause()` / `resume()` - when paused, the the code in PixiRenderer.js will not render
  *
  * Properties available:
  *   `dimensions`      The pixel dimensions of the map viewport [width,height]
@@ -152,6 +152,8 @@ export class MapSystem extends AbstractSystem {
    * @return {Promise} Promise resolved when this component has completed resetting
    */
   resetAsync() {
+    this._renderer?.scene?.reset();
+    this.immediateRedraw();
     return Promise.resolve();
   }
 
@@ -364,8 +366,7 @@ export class MapSystem extends AbstractSystem {
    * allow the changes to batch up over several animation frames.
    */
   deferredRedraw() {
-    if (!this._renderer || this._paused) return;
-    this._renderer.deferredRender();
+    this._renderer?.deferredRender();
   }
 
 
@@ -376,8 +377,7 @@ export class MapSystem extends AbstractSystem {
    * the map to update on one of the next few animation frames to show their change.
    */
   immediateRedraw() {
-    if (!this._renderer || this._paused) return;
-    this._renderer.render();
+    this._renderer?.render();
   }
 
 
@@ -844,7 +844,7 @@ export class MapSystem extends AbstractSystem {
    * @readonly
    */
   get scene() {
-    return this._renderer.scene;
+    return this._renderer?.scene;
   }
 
   /**

--- a/modules/core/UiSystem.js
+++ b/modules/core/UiSystem.js
@@ -188,7 +188,7 @@ this.didRender = true;
       .call(uiFullScreen(context));
 
     const map = context.systems.map;
-    map.redrawEnabled = false;  // don't draw until we've set zoom/lat/long
+    map.pause();  // don't draw until we've set zoom/lat/long
 
     container
       .append('svg')
@@ -429,7 +429,7 @@ this.didRender = true;
     // Setup map dimensions, and allow rendering..
     // This should happen after .main-content and toolbars exist.
     this.resize();
-    map.redrawEnabled = true;
+    map.resume();
 
     context.enter('browse');
 

--- a/modules/core/ValidationSystem.js
+++ b/modules/core/ValidationSystem.js
@@ -739,13 +739,13 @@ export class ValidationSystem extends AbstractSystem {
     // that won't make the browser stutter too badly.
     cache.queue = cache.queue.concat(utilArrayChunk(jobs, 50));
 
-    // Perform the work
-    if (cache.queuePromise) return cache.queuePromise;
-
-    cache.queuePromise = this._processQueue(cache)
-      .then(() => this._revalidateProvisionalEntities(cache))
-      .catch(e => console.error(e))  // eslint-disable-line
-      .finally(() => cache.queuePromise = null);
+    // Enqueue the work
+    if (!cache.queuePromise) {
+      cache.queuePromise = this._processQueue(cache)
+        .then(() => this._revalidateProvisionalEntities(cache))
+        .catch(e => console.error(e))  // eslint-disable-line
+        .finally(() => cache.queuePromise = null);
+    }
 
     return cache.queuePromise;
   }
@@ -820,9 +820,9 @@ class ValidationCache {
    * @param  which String 'base' or 'head' to keep track of it
    */
   constructor(which) {
-    this.which = which;
+    this.which = which;   // 'base' or 'head'
     this.graph = null;
-    this.queue = [];
+    this.queue = [];      // Array(jobs)
     this.queuePromise = null;
     this.queuedEntityIDs = new Set();
     this.provisionalEntityIDs = new Set();

--- a/modules/core/ValidationSystem.js
+++ b/modules/core/ValidationSystem.js
@@ -596,7 +596,11 @@ export class ValidationSystem extends AbstractSystem {
     }
 
     entityIDs = this._base.withAllRelatedEntities(entityIDs);  // expand set
-    return this._validateEntitiesAsync(this._base, entityIDs);
+
+    return this._validateEntitiesAsync(this._base, entityIDs)
+      .then(() => this._updateResolvedIssues(entityIDs))
+      .then(() => this.emit('validated'))
+      .catch(e => console.error(e));  // eslint-disable-line
   }
 
 

--- a/modules/pixi/AbstractLayer.js
+++ b/modules/pixi/AbstractLayer.js
@@ -66,6 +66,29 @@ export class AbstractLayer {
 
 
   /**
+   * reset
+   * Every Layer should have a reset function to clear out any state when a reset occurs.
+   * Override in a subclass with needed logic.
+   * @abstract
+   */
+  reset() {
+    this._featureHasData.clear();
+    this._dataHasFeature.clear();
+    this._parentHasChildren.clear();
+    this._childHasParents.clear();
+    this._dataHasClass.clear();
+    this._classHasData.clear();
+
+    for (const feature of this.features.values()) {
+      feature.destroy();
+    }
+
+    this.features.clear();
+    this.retained.clear();
+  }
+
+
+  /**
    * render
    * Every Layer should have a render function that manages the Features in view.
    * Override in a subclass with needed logic. It will be passed:

--- a/modules/pixi/PixiLayerBackgroundTiles.js
+++ b/modules/pixi/PixiLayerBackgroundTiles.js
@@ -50,6 +50,18 @@ export class PixiLayerBackgroundTiles extends AbstractLayer {
 
 
   /**
+   * reset
+   * Every Layer should have a reset function to clear out any state when a reset occurs.
+   */
+  reset() {
+    super.reset();
+    this.destroyAll();
+    this._tileMaps.clear();
+    this._failed.clear();
+  }
+
+
+  /**
    * render
    * @param  frame        Integer frame being rendered
    * @param  projection   Pixi projection to use for rendering

--- a/modules/pixi/PixiLayerEditBlocks.js
+++ b/modules/pixi/PixiLayerEditBlocks.js
@@ -18,7 +18,6 @@ export class PixiLayerEditBlocks extends AbstractLayer {
   constructor(scene, layerID) {
     super(scene, layerID);
     this.enabled = true;   // this layer should always be enabled
-    this._oldk = 0;
   }
 
 

--- a/modules/pixi/PixiLayerLabels.js
+++ b/modules/pixi/PixiLayerLabels.js
@@ -105,10 +105,12 @@ export class PixiLayerLabels extends AbstractLayer {
 
 
   /**
-   * resetAll
-   * Remove all label and debug objects from the scene and from all caches
+   * reset
+   * Every Layer should have a reset function to clear out any state when a reset occurs.
    */
-  resetAll() {
+  reset() {
+    super.reset();
+
     for (const label of this._labels.values()) {
 //      if (textureManager.get('text', label.str)) {
 //        textureManager.free('text', label.str);
@@ -183,7 +185,7 @@ export class PixiLayerLabels extends AbstractLayer {
       // Reset all labels and avoids when scale changes
       const k = projection.scale();
       if (k !== this._oldk) {
-        this.resetAll();
+        this.reset();
         this._oldk = k;
       }
 

--- a/modules/pixi/PixiLayerMapillaryPhotos.js
+++ b/modules/pixi/PixiLayerMapillaryPhotos.js
@@ -49,7 +49,6 @@ export class PixiLayerMapillaryPhotos extends AbstractLayer {
 
     if (this.supported) {
       const service = this.context.services.mapillary;
-
       service.on('bearingChanged', this._handleBearingChange);
       service.on('fovChanged', this._handleFovChange);
     }

--- a/modules/pixi/PixiLayerOsm.js
+++ b/modules/pixi/PixiLayerOsm.js
@@ -107,6 +107,16 @@ export class PixiLayerOsm extends AbstractLayer {
 
 
   /**
+   * reset
+   * Every Layer should have a reset function to clear out any state when a reset occurs.
+   */
+  reset() {
+    super.reset();
+    this._resolved.clear();
+  }
+
+
+  /**
    * render
    * Render any data we have, and schedule fetching more of it to cover the view
    * @param  frame        Integer frame being rendered

--- a/modules/pixi/PixiLayerRapid.js
+++ b/modules/pixi/PixiLayerRapid.js
@@ -139,6 +139,16 @@ export class PixiLayerRapid extends AbstractLayer {
 
 
   /**
+   * reset
+   * Every Layer should have a reset function to clear out any state when a reset occurs.
+   */
+  reset() {
+    super.reset();
+    this._resolved.clear();
+  }
+
+
+  /**
    * render
    * Render any data we have, and schedule fetching more of it to cover the view
    * @param  frame        Integer frame being rendered

--- a/modules/pixi/PixiLayerStreetsidePhotos.js
+++ b/modules/pixi/PixiLayerStreetsidePhotos.js
@@ -37,7 +37,6 @@ export class PixiLayerStreetsidePhotos extends AbstractLayer {
 
     if (this.supported) {
       const service = this.context.services.streetside;
-
       service.on('viewerChanged', this._handleBearingChange);
     }
   }

--- a/modules/pixi/PixiRenderer.js
+++ b/modules/pixi/PixiRenderer.js
@@ -409,12 +409,15 @@ export class PixiRenderer extends EventEmitter {
     // Wait for textures to be loaded before attempting rendering.
     if (!this.textures?.loaded) return;
 
-    // Reproject the pixi geometries only whenever zoom changes
     const context = this.context;
+    const map = context.systems.map;
+    if (map.paused) return;
+
+    // Reproject the pixi geometries only whenever zoom changes
     const pixiProjection = this.pixiProjection;
     const pixiTransform = pixiProjection.transform();
     const mapTransform = context.projection.transform();
-    const effectiveZoom = context.systems.map.effectiveZoom();
+    const effectiveZoom = map.effectiveZoom();
 
     const pixiXY = [pixiTransform.x, pixiTransform.y];
     const mapXY = [mapTransform.x, mapTransform.y];

--- a/modules/pixi/PixiScene.js
+++ b/modules/pixi/PixiScene.js
@@ -113,6 +113,18 @@ export class PixiScene extends EventEmitter {
 
 
   /**
+   * reset
+   * Calls each Layer's `reset' method.
+   * This is used to clear out any state when a reset occurs.
+   */
+  reset() {
+    for (const layer of this.layers.values()) {
+      layer.reset();
+    }
+  }
+
+
+  /**
    * render
    * Calls each Layer's `render` and `cull` methods
    * - `render` will create and update the Features that belong in the scene

--- a/modules/services/EsriService.js
+++ b/modules/services/EsriService.js
@@ -34,7 +34,6 @@ export class EsriService extends AbstractSystem {
     this._tiler = new Tiler().zoomRange(TILEZOOM);
     this._datasets = {};
     this._gotDatasets = false;
-    this._off = false;
 
     // Ensure methods used as callbacks always have `this` bound correctly.
     this._parseDataset = this._parseDataset.bind(this);
@@ -102,7 +101,7 @@ export class EsriService extends AbstractSystem {
    * @param   {string}  datasetID - datasetID to load tiles for
    */
   loadTiles(datasetID) {
-    if (this._off) return;
+    if (this._paused) return;
 
     // `loadDatasetsAsync` and `loadLayerAsync` are asynchronous,
     // so ensure both have completed before we start requesting tiles.
@@ -142,11 +141,6 @@ export class EsriService extends AbstractSystem {
   graph(datasetID)  {
     const ds = this._datasets[datasetID];
     return ds?.graph;
-  }
-
-
-  toggle(val) {
-    this._off = !val;
   }
 
 

--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -29,7 +29,6 @@ export class MapWithAIService extends AbstractSystem {
     this._tiler = new Tiler().zoomRange(TILEZOOM);
     this._datasets = {};
     this._deferred = new Set();
-    this._off = false;
 
     // Ensure methods used as callbacks always have `this` bound correctly.
     this._parseNode = this._parseNode.bind(this);
@@ -111,7 +110,7 @@ export class MapWithAIService extends AbstractSystem {
    * @param   {string}  datasetID - datasetID to load tiles for
    */
   loadTiles(datasetID) {
-    if (this._off) return;
+    if (this._paused) return;
 
     let ds = this._datasets[datasetID];
     let graph, tree, cache;
@@ -190,11 +189,6 @@ export class MapWithAIService extends AbstractSystem {
     if (!ds || !ds.tree || !ds.graph) return;
     ds.graph.rebase(entities, [ds.graph], false);
     ds.tree.rebase(entities, false);
-  }
-
-
-  toggle(val) {
-    this._off = !val;
   }
 
 

--- a/modules/services/OsmService.js
+++ b/modules/services/OsmService.js
@@ -52,7 +52,6 @@ export class OsmService extends AbstractSystem {
     this._userChangesets = undefined;
     this._userDetails = undefined;
     this._cachedApiStatus = undefined;
-    this._off = false;
 
     // Ensure methods used as callbacks always have `this` bound correctly.
     this._authLoading = this._authLoading.bind(this);
@@ -165,11 +164,6 @@ export class OsmService extends AbstractSystem {
 //        this.userChangesets(function() {});  // eagerly load user details/changesets
         this.emit('authchange');
       });
-  }
-
-
-  toggle(val) {
-    this._off = !val;
   }
 
 
@@ -693,7 +687,7 @@ export class OsmService extends AbstractSystem {
   // Load data (entities) from the API in tiles
   // GET /api/0.6/map?bbox=
   loadTiles(projection, callback) {
-    if (this._off) return;
+    if (this._paused) return;
 
     // determine the needed tiles to cover the view
     const tiles = this._tiler
@@ -720,7 +714,7 @@ export class OsmService extends AbstractSystem {
   // Load a single data tile
   // GET /api/0.6/map?bbox=
   loadTile(tile, callback) {
-    if (this._off) return;
+    if (this._paused) return;
 
     const cache = this._tileCache;
     if (cache.loaded[tile.id] || cache.inflight[tile.id]) return;
@@ -798,7 +792,7 @@ export class OsmService extends AbstractSystem {
   // Load notes from the API in tiles
   // GET /api/0.6/notes?bbox=
   loadNotes(projection, noteOptions) {
-    if (this._off) return;
+    if (this._paused) return;
     noteOptions = Object.assign({ limit: 10000, closed: 7 }, noteOptions);
 
     const cache = this._noteCache;

--- a/modules/ui/intro/intro.js
+++ b/modules/ui/intro/intro.js
@@ -124,7 +124,7 @@ export function uiIntro(context, skipToRapid) {
 
     // Disable OSM
     if (osm) {
-      osm.toggle(false);
+      osm.pause();
     }
 
     // Load walkthrough data
@@ -159,7 +159,7 @@ export function uiIntro(context, skipToRapid) {
     });
 
     if (mapwithai) {
-      mapwithai.toggle(false);    // disable network
+      mapwithai.pause();    // disable network
       mapwithai.merge('rapid_intro_graph', Object.values(_rapidGraph));
     }
 
@@ -286,11 +286,11 @@ export function uiIntro(context, skipToRapid) {
       context.resetAsync()
         .then(() => {
           if (osm) {
-            osm.toggle(true);
+            osm.resume();
           }
 
           if (mapwithai) {
-            mapwithai.toggle(true);
+            mapwithai.resume();
           }
 
           if (original.edits) {

--- a/modules/ui/intro/intro.js
+++ b/modules/ui/intro/intro.js
@@ -123,9 +123,7 @@ export function uiIntro(context, skipToRapid) {
     context.container().selectAll('button.sidebar-toggle').classed('disabled', true);
 
     // Disable OSM
-    if (osm) {
-      osm.pause();
-    }
+    osm?.pause();
 
     // Load walkthrough data
     editor.reset();
@@ -285,13 +283,8 @@ export function uiIntro(context, skipToRapid) {
       // Restore edits and re-enable services.
       context.resetAsync()
         .then(() => {
-          if (osm) {
-            osm.resume();
-          }
-
-          if (mapwithai) {
-            mapwithai.resume();
-          }
+          osm?.resume();
+          mapwithai?.resume();
 
           if (original.edits) {
             editor.fromJSON(original.edits, true);

--- a/modules/ui/intro/intro.js
+++ b/modules/ui/intro/intro.js
@@ -55,7 +55,12 @@ export function uiIntro(context, skipToRapid) {
 
   let _introGraph = {};
   let _rapidGraph = {};
+  let _original = {};
+  let _progress = [];
   let _currChapter;
+  let _buttons;
+  let _curtain;
+  let _navwrap;
 
 
   /**
@@ -90,7 +95,7 @@ export function uiIntro(context, skipToRapid) {
 
   /**
    * _startIntro
-   * Call this to render the intro walkthrough
+   * After the walkthrough data has been loaded, this starts the walkthrough.
    * @param  selection  D3-selection to render the walkthrough content into (the root container)
    */
   function _startIntro(selection) {
@@ -99,7 +104,7 @@ export function uiIntro(context, skipToRapid) {
     context.enter('browse');
 
     // Save current state
-    const original = {
+    _original = {
       hash: window.location.hash,
       transform: map.transform(),
       brightness: imagery.brightness,
@@ -113,7 +118,7 @@ export function uiIntro(context, skipToRapid) {
     // Remember which layers were enabled before, enable only certain ones in the walkthrough.
     for (const [layerID, layer] of context.scene().layers) {
       if (layer.enabled) {
-        original.layersEnabled.add(layerID);
+        _original.layersEnabled.add(layerID);
       }
     }
     context.scene().onlyLayers(['background', 'osm', 'labels']);
@@ -125,21 +130,16 @@ export function uiIntro(context, skipToRapid) {
     // Disable OSM
     osm?.pause();
 
-    // Load walkthrough data
-    editor.reset();
-    editor.merge(Object.values(_introGraph));
-    editor.setCheckpoint('initial');
-
     // Setup imagery
     const introSource = imagery.getSource(INTRO_IMAGERY) || imagery.getSource('Bing');
     imagery.baseLayerSource(introSource);
-    original.overlayLayers.forEach(d => imagery.toggleOverlayLayer(d));
+    _original.overlayLayers.forEach(d => imagery.toggleOverlayLayer(d));
     imagery.brightness = 1;
 
     // Setup Rapid Walkthrough dataset and disable service
     for (const [datasetID, dataset] of rapid.datasets) {
       if (dataset.enabled) {
-        original.datasetsEnabled.add(datasetID);
+        _original.datasetsEnabled.add(datasetID);
         dataset.enabled = false;
       }
     }
@@ -161,27 +161,27 @@ export function uiIntro(context, skipToRapid) {
       mapwithai.merge('rapid_intro_graph', Object.values(_rapidGraph));
     }
 
-    const curtain = new UiCurtain(context);
-    selection.call(curtain.enable);
+    _curtain = new UiCurtain(context);
+    selection.call(_curtain.enable);
 
     // Store that the user started the walkthrough..
     storage.setItem('walkthrough_started', 'yes');
 
     // Restore previous walkthrough progress..
     const storedProgress = storage.getItem('walkthrough_progress') || '';
-    const progress = storedProgress.split(';').filter(Boolean);
+    _progress = storedProgress.split(';').filter(Boolean);
 
     // Create the chapters
     const chapters = chapterFlow.map((chapterID, i) => {
-      const s = chapterUi[chapterID](context, curtain)
+      const s = chapterUi[chapterID](context, _curtain)
         .on('done', () => {    // When completing each chapter..
-          buttons
+          _buttons
             .filter(d => d.title === s.title)
             .classed('finished', true);
 
           // Store walkthrough progress..
-          progress.push(chapterID);
-          storage.setItem('walkthrough_progress', utilArrayUniq(progress).join(';'));
+          _progress.push(chapterID);
+          storage.setItem('walkthrough_progress', utilArrayUniq(_progress).join(';'));
 
           if (i < chapterFlow.length - 1) {
             const nextID = chapterFlow[i + 1];
@@ -195,107 +195,115 @@ export function uiIntro(context, skipToRapid) {
     });
 
 
-    let navwrap = selection
+    _navwrap = selection
       .append('div')
       .attr('class', 'intro-nav-wrap fillD');
 
-    navwrap
+    _navwrap
       .append('svg')
       .attr('class', 'intro-nav-wrap-logo')
       .append('use')
       .attr('xlink:href', '#rapid-logo-walkthrough');
 
-    let buttonwrap = navwrap
+    const buttonwrap = _navwrap
       .append('div')
       .attr('class', 'joined')
       .selectAll('button.chapter');
 
-    let buttons = buttonwrap
+    _buttons = buttonwrap
       .data(chapters)
       .enter()
       .append('button')
       .attr('class', (d, i) => `chapter chapter-${chapterFlow[i]}`)
       .on('click', _enterChapter);
 
-    buttons
+    _buttons
       .append('span')
       .html(d => l10n.tHtml(d.title));
 
-    buttons
+    _buttons
       .append('span')
       .attr('class', 'status')
       .call(uiIcon(l10n.isRTL() ? '#rapid-icon-backward' : '#rapid-icon-forward', 'inline'));
 
-    _enterChapter(null, chapters[skipToRapid ? 6 : 0]);
 
-
-    /**
-     * _enterChapter
-     * Call this to enter a new chapter.
-     * Either called explicitly or by clicking a button the chapter navigation bar.
-     * @param  d3_event    If clicked on a button, the click event (not used)
-     * @param  newChapter  The chapter to enter
-     */
-    function _enterChapter(d3_event, newChapter) {
-      if (_currChapter) _currChapter.exit();
-      context.enter('browse');
-
-      _currChapter = newChapter;
-      _currChapter.enter();
-
-      buttons
-        .classed('next', false)
-        .classed('active', d => d.title === _currChapter.title);
-    }
-
-
-    /**
-     * _finish
-     * Cleanup, restore state, and leave the walkthrough
-     */
-    function _finish() {
-      // Store if walkthrough is completed..
-      const incomplete = utilArrayDifference(chapterFlow, progress);
-      if (!incomplete.length) {
-        storage.setItem('walkthrough_completed', 'yes');
-      }
-
-      // Restore Rapid datasets and service
-      for (const [datasetID, dataset] of rapid.datasets) {
-        dataset.enabled = original.datasetsEnabled.has(datasetID);
-      }
-      rapid.datasets.delete('rapid_intro_graph');
-
-      curtain.disable();
-      navwrap.remove();
-      context.container().selectAll('button.sidebar-toggle').classed('disabled', false);
-
-      // Restore Map State
-      for (const [layerID, layer] of context.scene().layers) {
-        layer.enabled = original.layersEnabled.has(layerID);
-      }
-      imagery.baseLayerSource(original.baseLayer);
-      original.overlayLayers.forEach(d => imagery.toggleOverlayLayer(d));
-      imagery.brightness = original.brightness;
-      map.transform(original.transform);
-      window.location.replace(original.hash);
-
-      // Restore edits and re-enable services.
-      context.resetAsync()
-        .then(() => {
-          osm?.resume();
-          mapwithai?.resume();
-
-          if (original.edits) {
-            editor.fromJSON(original.edits, true);
-          }
-
-          context.inIntro = false;
-          urlhash.enable();
-        });
-    }
-
+    // Reset, then load the data into the editor and start.
+    context.resetAsync()
+      .then(() => {
+        editor.merge(Object.values(_introGraph));
+        editor.setCheckpoint('initial');
+        _enterChapter(null, chapters[skipToRapid ? 6 : 0]);
+      });
   }
+
+
+  /**
+   * _enterChapter
+   * Call this to enter a new chapter.
+   * Either called explicitly or by clicking a button the chapter navigation bar.
+   * @param  d3_event    If clicked on a button, the click event (not used)
+   * @param  newChapter  The chapter to enter
+   */
+  function _enterChapter(d3_event, newChapter) {
+    if (_currChapter) _currChapter.exit();
+    context.enter('browse');
+
+    _currChapter = newChapter;
+    _currChapter.enter();
+
+    _buttons
+      .classed('next', false)
+      .classed('active', d => d.title === _currChapter.title);
+  }
+
+
+  /**
+   * _finish
+   * Cleanup, restore state, and leave the walkthrough
+   */
+  function _finish() {
+    // Store if walkthrough is completed..
+    const incomplete = utilArrayDifference(chapterFlow, _progress);
+    if (!incomplete.length) {
+      storage.setItem('walkthrough_completed', 'yes');
+    }
+
+    // Restore Rapid datasets and service
+    for (const [datasetID, dataset] of rapid.datasets) {
+      dataset.enabled = _original.datasetsEnabled.has(datasetID);
+    }
+    rapid.datasets.delete('rapid_intro_graph');
+
+    _curtain.disable();
+    _navwrap.remove();
+    context.container().selectAll('button.sidebar-toggle').classed('disabled', false);
+
+    // Restore Map State
+    for (const [layerID, layer] of context.scene().layers) {
+      layer.enabled = _original.layersEnabled.has(layerID);
+    }
+    imagery.baseLayerSource(_original.baseLayer);
+    _original.overlayLayers.forEach(d => imagery.toggleOverlayLayer(d));
+    imagery.brightness = _original.brightness;
+    map.transform(_original.transform);
+    window.location.replace(_original.hash);
+
+    osm?.resume();
+    mapwithai?.resume();
+    context.inIntro = false;
+    urlhash.enable();
+
+    // Reset, then restore the user's edits, if any...
+    context.resetAsync()
+      .then(() => {
+        if (_original.edits) {
+          return editor.fromJSONAsync(_original.edits);
+        } else {
+          return Promise.resolve();
+        }
+      });
+  }
+
 
   return intro;
 }

--- a/test/spec/core/EditSystem.test.js
+++ b/test/spec/core/EditSystem.test.js
@@ -86,7 +86,6 @@ describe('EditSystem', () => {
 
   const context = new MockContext();
 
-
   beforeEach(() => {
     _editor = new Rapid.EditSystem(context);
     return _editor.initAsync();
@@ -762,7 +761,7 @@ describe('EditSystem', () => {
   });
 
 
-  describe('#fromJSON', () => {
+  describe('#fromJSONAsync', () => {
     it('restores from v3 JSON (creation)', () => {
       const json = {
         version: 3,
@@ -775,12 +774,14 @@ describe('EditSystem', () => {
         nextIDs: { node: -2, way: -1, relation: -1 },
         index: 1
       };
-      _editor.fromJSON(JSON.stringify(json));
-      expect(_editor.staging.graph.entity('n-1')).to.eql(Rapid.osmNode({id: 'n-1', loc: [1, 2]}));
-      expect(_editor.getUndoAnnotation()).to.eql('Added a point.');
-      expect(_editor.sourcesUsed().imagery).to.include('Bing');
-      expect(Rapid.osmEntity.id.next).to.eql({ node: -2, way: -1, relation: -1 });
-      expect(_editor.difference().created().length).to.eql(1);
+      return _editor.fromJSONAsync(JSON.stringify(json))
+        .then(() => {
+          expect(_editor.staging.graph.entity('n-1')).to.eql(Rapid.osmNode({id: 'n-1', loc: [1, 2]}));
+          expect(_editor.getUndoAnnotation()).to.eql('Added a point.');
+          expect(_editor.sourcesUsed().imagery).to.include('Bing');
+          expect(Rapid.osmEntity.id.next).to.eql({ node: -2, way: -1, relation: -1 });
+          expect(_editor.difference().created().length).to.eql(1);
+        });
     });
 
     it('restores from v3 JSON (modification)', () => {
@@ -795,12 +796,14 @@ describe('EditSystem', () => {
         nextIDs: { node: -2, way: -1, relation: -1 },
         index: 1
       };
-      _editor.fromJSON(JSON.stringify(json));
-      expect(_editor.staging.graph.entity('n1')).to.eql(Rapid.osmNode({ id: 'n1', loc: [2, 3], v: 1 }));
-      expect(_editor.getUndoAnnotation()).to.eql('Moved a point.');
-      expect(_editor.sourcesUsed().imagery).to.include('Bing');
-      expect(Rapid.osmEntity.id.next).to.eql({ node: -2, way: -1, relation: -1 });
-      expect(_editor.difference().modified().length).to.eql(1);
+      return _editor.fromJSONAsync(JSON.stringify(json))
+        .then(() => {
+          expect(_editor.staging.graph.entity('n1')).to.eql(Rapid.osmNode({ id: 'n1', loc: [2, 3], v: 1 }));
+          expect(_editor.getUndoAnnotation()).to.eql('Moved a point.');
+          expect(_editor.sourcesUsed().imagery).to.include('Bing');
+          expect(Rapid.osmEntity.id.next).to.eql({ node: -2, way: -1, relation: -1 });
+          expect(_editor.difference().modified().length).to.eql(1);
+        });
     });
 
     it('restores from v3 JSON (deletion)', () => {
@@ -815,12 +818,14 @@ describe('EditSystem', () => {
         nextIDs: { node: -1, way: -2, relation: -3 },
         index: 1
       };
-      _editor.fromJSON(JSON.stringify(json));
-      expect(_editor.staging.graph.hasEntity('n1')).to.be.undefined;
-      expect(_editor.getUndoAnnotation()).to.eql('Deleted a point.');
-      expect(_editor.sourcesUsed().imagery).to.include('Bing');
-      expect(Rapid.osmEntity.id.next).to.eql({ node: -1, way: -2, relation: -3 });
-      expect(_editor.difference().deleted().length).to.eql(1);
+      return _editor.fromJSONAsync(JSON.stringify(json))
+        .then(() => {
+          expect(_editor.staging.graph.hasEntity('n1')).to.be.undefined;
+          expect(_editor.getUndoAnnotation()).to.eql('Deleted a point.');
+          expect(_editor.sourcesUsed().imagery).to.include('Bing');
+          expect(Rapid.osmEntity.id.next).to.eql({ node: -1, way: -2, relation: -3 });
+          expect(_editor.difference().deleted().length).to.eql(1);
+        });
     });
   });
 });

--- a/test/spec/core/EditSystem.test.js
+++ b/test/spec/core/EditSystem.test.js
@@ -44,6 +44,8 @@ describe('EditSystem', () => {
     constructor() { }
     initAsync()   { return Promise.resolve(); }
     on()          { return this; }
+    pause()       { }
+    resume()      { }
   }
 
   class MockImagerySystem {


### PR DESCRIPTION
(closes https://github.com/facebook/Rapid/issues/1074)

Hopefully fixes this longstanding issue!

The main issue with this `fromJSON` function is a common source of bugs in our code:  treating async things as if they are sync, or vice versa.

`fromJSON` was especially gnarly beacuse it can work either way - normally it would be sync, unless it needs to go looking for missing OSM entities, then it becomes async.

Now that more parts of the code are async / promisified - this code needs to be also. It's now a Promise-returning function (hence the "async" in the name) intended to be chained after a `context.resetAsync()` to ensure that we are starting with a clean slate.

527deb71 changes `fromJSON` to `fromJSONAsync`, and updates both the restore code in EditSystem, and also the code to enter and leave the walkthrough, these are the only 2 places where we use `fromJSON`.  (and tests too)

This PR also includes some related work to make sure resets are more reliable: 
 - 1cd16e0 adds some `pause()` and `resume()` functions to `AbstractSystem`.  Only a few systems can "pause" and "resume" but it is used often enough that it's nice to have a more consistent way to tell a system or service to pause.
 - 7b13ce5 adds a fix for the validator to make sure that upon validating the base graph, we also update the resolved issues counts and dispatch a validated event (before the UI / counts might lag until the user touched something)
 - e2b164d8 adds ability for the renderer to reset / clear out it's internal state - we were running into situations where the renderer would have old state that should have been reset.  `MapSystem.resetAsync` is now responsible for calling `reset()` on the scene, and then scheduling a redraw on the next tick.