### PR TITLE
Revert "feat: add operation for cycling crosswalk tags"

### DIFF
--- a/modules/operations/cycle_highway_tag.js
+++ b/modules/operations/cycle_highway_tag.js
@@ -43,9 +43,6 @@ export function operationCycleHighwayTag(context, selectedIDs) {
     'highway/footway/crossing/ladder:skewed',
   ];
 
-  // Do not allow multi-select.
-  if (selectedIDs.length > 1) return false;
-
   const selectedID = selectedIDs[0];
   const entity = graph.hasEntity(selectedID);
 


### PR DESCRIPTION
Reverts facebook/Rapid#1160

This PR should not have been merged in, as a different, more up-to-date version of the PR was landed instead. 

Until we merge this PR, attempting to select multiple ways will result in a crash as the selection code will be receiving 'false' instead of an actual cycle highway tags operation object to evaluate. 