### PR TITLE
Rotate to move mode key behavior restored from V1

### DIFF
--- a/modules/modes/MoveMode.js
+++ b/modules/modes/MoveMode.js
@@ -136,6 +136,9 @@ export class MoveMode extends AbstractMode {
     } else if (['Backspace', 'Delete', 'Del', 'Escape', 'Esc'].includes(e.key)) {
       e.preventDefault();
       this._cancel();
+    } else if (['r', 'R'].includes(e.key)) {
+      e.preventDefault();
+      this._rotateMode();
     }
   }
 
@@ -179,6 +182,14 @@ export class MoveMode extends AbstractMode {
    */
   _finish() {
     this.context.enter('select-osm', { selection: { osm: this._entityIDs }} );
+  }
+
+  /**
+   * _rotateMode
+   * Return to roate mode if e.key is pressed
+   */
+  _rotateMode() {
+    this.context.enter('rotate', { selection: { osm: this._entityIDs }} );
   }
 
 

--- a/modules/modes/RotateMode.js
+++ b/modules/modes/RotateMode.js
@@ -137,6 +137,9 @@ export class RotateMode extends AbstractMode {
     } else if (['Backspace', 'Delete', 'Del', 'Escape', 'Esc'].includes(e.key)) {
       e.preventDefault();
       this._cancel();
+    } else if (['m', 'M'].includes(e.key)) {
+      e.preventDefault();
+      this._moveMode();
     }
   }
 
@@ -243,6 +246,15 @@ export class RotateMode extends AbstractMode {
    */
   _finish() {
     this.context.enter('select-osm', { selection: { osm: this._entityIDs }} );
+  }
+
+
+  /**
+   * _rotateMode
+   * Return to move mode if e.key is pressed
+   */
+  _moveMode() {
+    this.context.enter('move', { selection: { osm: this._entityIDs }} );
   }
 
 


### PR DESCRIPTION
## Description

Now the user can switch from move mode to rotate mode (and vice versa) like in Rapid V1.

## Background

When selecting a building, hit M key to move it and R key to rotate it


https://github.com/facebook/Rapid/assets/49957271/398e2773-06c2-4eb6-bf20-3fb99c0b6a46




## Related Tickets 
fixes #818