### PR TITLE
Added map nudging so when user is adding a node it will nudge the edge of the map

### DIFF
--- a/modules/modes/AddPointMode.js
+++ b/modules/modes/AddPointMode.js
@@ -84,6 +84,7 @@ export class AddPointMode extends AbstractMode {
    * Process whatever the user clicked on
    */
   _click(eventData) {
+    // console.log('HITTT');
     const context = this.context;
     const editor = context.systems.editor;
     const graph = editor.staging.graph;
@@ -93,7 +94,6 @@ export class AddPointMode extends AbstractMode {
 
     const loc = projection.invert(coord);
     if (locations.blocksAt(loc).length) return;   // editing is blocked here
-
     // Allow snapping only for OSM Entities in the actual graph (i.e. not Rapid features)
     const datum = eventData?.target?.data;
     const choice = eventData?.target?.choice;
@@ -120,7 +120,8 @@ export class AddPointMode extends AbstractMode {
         return;
       }
     }
-
+    // Now that the user has clicked, let them nudge the map by moving to the edge.
+    context.behaviors['map-nudging'].allow();
     this._clickNothing(loc);
   }
 

--- a/modules/modes/DragNodeMode.js
+++ b/modules/modes/DragNodeMode.js
@@ -112,7 +112,9 @@ export class DragNodeMode extends AbstractMode {
     const clickCoord = context.behaviors.drag.lastDown.coord;
     this._clickLoc = context.projection.invert(clickCoord);
 
-    context.enableBehaviors(['hover', 'drag']);
+    context.enableBehaviors(['hover', 'drag', 'map-nudging']);
+    // Now that the user has clicked, let them nudge the map by moving to the edge.
+    context.behaviors['map-nudging'].allow();
 
     context.behaviors.drag
       .on('move', this._move)

--- a/modules/modes/DrawLineMode.js
+++ b/modules/modes/DrawLineMode.js
@@ -113,6 +113,8 @@ export class DrawLineMode extends AbstractMode {
     eventManager.setCursor('crosshair');
 
     context.enableBehaviors(['hover', 'draw', 'map-interaction', 'map-nudging']);
+    // Now that the user has clicked, let them nudge the map by moving to the edge.
+    context.behaviors['map-nudging'].allow();
 
     context.behaviors.hover
       .on('hoverchange', this._hover);


### PR DESCRIPTION
## Description 
If you extend a way with the 'a' shortcut, or just drag a node around, 'nudge' the map when you get near the edge works 

fixed #1052


https://github.com/facebook/Rapid/assets/49957271/6324801e-686b-4afb-831a-1d3baa2d16e3

