### PR TITLE
Fix #1265 

### DIFF
--- a/modules/ui/inspector.js
+++ b/modules/ui/inspector.js
@@ -140,9 +140,9 @@ export function uiInspector(context) {
       presetList.selected(selected);
     }
 
-    // render
+    // render and autofocus only if the feature is new.
     presetPane
-      .call(presetList.autofocus(true));
+      .call(presetList.autofocus(_newFeature));
   };
 
 
@@ -179,6 +179,8 @@ export function uiInspector(context) {
       inspector.showPresetList();
     } else {
       const choice = preset ? [preset] : null;
+      const input = presetPane.select('.preset-search-input').node();
+      input.value = '';
       inspector.showEntityEditor(choice, true);  // true = animate
     }
   };


### PR DESCRIPTION
A quick PR for review of the broken keyboard input issues with 2.2.0. @bhousel's intuition was correct- we were stealing focus too zealously. 

This fixes the issue by only autofocusing the preset search input for _new_ features, and it also clears the text input after the user makes a selection.