### PR TITLE
Integrate colorblind and map color scheme UI to preference tab

### DIFF
--- a/data/colors.json
+++ b/data/colors.json
@@ -37,7 +37,7 @@
       "fill": { "color": "0xaaaaaa", "alpha": 0.3 }
     }
   },
-  "example": {
+  "high_contrast": {
     "red": {
       "fill": { "color": "0xFF0E41", "alpha": 0.3 }
     },

--- a/data/colors.json
+++ b/data/colors.json
@@ -1,0 +1,78 @@
+{
+  "default": {
+    "red": {
+      "fill": { "color": "0xe06e5f", "alpha": 0.3 }
+    },
+    "green": {
+      "fill": { "color": "0x8cd05f", "alpha": 0.3 }
+    },
+    "blue": {
+      "fill": { "color": "0x77d4de", "alpha": 0.3 }
+    },
+    "yellow": {
+      "fill": { "color": "0xffff94", "alpha": 0.25 }
+    },
+    "gold": {
+      "fill": { "color": "0xc4be19", "alpha": 0.3 }
+    },
+    "orange": {
+      "fill": { "color": "0xd6881a", "alpha": 0.3 }
+    },
+    "pink": {
+      "fill": { "color": "0xe3a4f5", "alpha": 0.3 }
+    },
+    "teal": {
+      "fill": { "color": "0x99e1aa", "alpha": 0.3 }
+    },
+    "lightgreen": {
+      "fill": { "color": "0xbee83f", "alpha": 0.3 }
+    },
+    "tan": {
+      "fill": { "color": "0xf5dcba", "alpha": 0.3 }
+    },
+    "darkgray": {
+      "fill": { "color": "0x8c8c8c", "alpha": 0.5 }
+    },
+    "lightgray": {
+      "fill": { "color": "0xaaaaaa", "alpha": 0.3 }
+    }
+  },
+  "example": {
+    "red": {
+      "fill": { "color": "0xFF0E41", "alpha": 0.3 }
+    },
+    "green": {
+      "fill": { "color": "0x09F04A", "alpha": 0.3 }
+    },
+    "blue": {
+      "fill": { "color": "0x0CBCFF", "alpha": 0.3 }
+    },
+    "yellow": {
+      "fill": { "color": "0xFFCA09", "alpha": 0.25 }
+    },
+    "gold": {
+      "fill": { "color": "0xFF0EBC", "alpha": 0.3 }
+    },
+    "orange": {
+      "fill": { "color": "0xFF510B", "alpha": 0.3 }
+    },
+    "pink": {
+      "fill": { "color": "0xF1C0E8", "alpha": 0.3 }
+    },
+    "teal": {
+      "fill": { "color": "0x12FFD1", "alpha": 0.3 }
+    },
+    "lightgreen": {
+      "fill": { "color": "0x540FFF", "alpha": 0.3 }
+    },
+    "tan": {
+      "fill": { "color": "0xAFFA1F", "alpha": 0.3 }
+    },
+    "darkgray": {
+      "fill": { "color": "0x0000FE", "alpha": 0.5 }
+    },
+    "lightgray": {
+      "fill": { "color": "0xE9AF1E", "alpha": 0.3 }
+    }
+  }
+}

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1000,7 +1000,7 @@ en:
       title: Map Color Scheme
       tooltip: Switch between color schemes
       default: Default
-      example: Example (High Contrast)
+      high_contrast: High Contrast
       placeholder: Select color scheme
     colorblind_options:
       title: Colorblind Mode

--- a/modules/core/DataLoaderSystem.js
+++ b/modules/core/DataLoaderSystem.js
@@ -23,6 +23,7 @@ export class DataLoaderSystem extends AbstractSystem {
 
     const fileMap  = new Map();
     fileMap.set('address_formats', 'data/address_formats.min.json');
+    fileMap.set('colors', 'data/colors.min.json');
     fileMap.set('deprecated', 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@6.6/dist/deprecated.min.json');
     fileMap.set('discarded', 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@6.6/dist/discarded.min.json');
     fileMap.set('imagery', 'data/imagery.min.json');

--- a/modules/core/StyleSystem.js
+++ b/modules/core/StyleSystem.js
@@ -35,9 +35,6 @@ export class StyleSystem extends AbstractSystem {
     this.context = context;
     this.dependencies = new Set(['dataloader']);
     this.autoStart = true;
-
-    // To handle color schemes
-    this.colorData = null;
     this.colorSchemes = null;
     this.currentColorScheme = null;
 
@@ -521,10 +518,9 @@ export class StyleSystem extends AbstractSystem {
 
 
     this.styleMatch = this.styleMatch.bind(this);
-
-    // To handle color schemes
     this.getColorScheme = this.getColorScheme.bind(this);
     this.getAllColorSchemes = this.getAllColorSchemes.bind(this);
+    this.setColorScheme = this.setColorScheme.bind(this);
   }
 
 
@@ -550,17 +546,16 @@ export class StyleSystem extends AbstractSystem {
   startAsync() {
     this._started = true;
 
-    // To handle color schemes
+    // Fetch the color scheme objects from colors.json
     const context = this.context;
     const dataloader = context.systems.dataloader;
 
     dataloader.getDataAsync('colors')
       .then((data) => {
         this.colorSchemes = data;
-        // set current scheme to default
-        this.colorData = data.default;
-        this.currentColorScheme = 'default';
-        this.emit('colorsloaded');  // emit copies
+        // Set the current color scheme to default
+        this.currentColorScheme = data.default;
+        this.emit('colorsloaded');
       });
 
     return Promise.resolve();
@@ -581,7 +576,7 @@ export class StyleSystem extends AbstractSystem {
    * @return {Object}  Default color scheme object
    */
   getColorScheme() {
-    return this.colorData;
+    return this.currentColorScheme;
   }
 
   /**
@@ -594,14 +589,13 @@ export class StyleSystem extends AbstractSystem {
 
   /**
    * setColorScheme
-   * Assigns the colorData var to the new scheme, if the selected scheme is not the current scheme
+   * Assigns the currentColorScheme var to the new scheme, if the selected scheme is not the current scheme
    * @param  {Object}  scheme - color scheme project
    */
   setColorScheme(scheme) {
     let currentScheme = this.colorSchemes[scheme];
-    if (this.colorData !== currentScheme) { 
-      this.currentColorScheme = scheme;
-      this.colorData = currentScheme;
+    if (this.currentColorScheme !== currentScheme) { 
+      this.currentColorScheme = currentScheme;
     }
   }
 

--- a/modules/ui/panes/preferences.js
+++ b/modules/ui/panes/preferences.js
@@ -1,8 +1,8 @@
 import { uiPane } from '../pane.js';
 import { uiSectionPrivacy } from '../sections/privacy.js';
-//import { uiSectionColorSelection } from '../sections/color_selection.js';
-//import { uiSectionColorblindModeOptions } from '../sections/colorblind_mode_options.js';
 import { uiSectionMapInteractionOptions } from '../sections/map_interaction_options.js';
+import { uiSectionColorSelection } from '../sections/color_selection.js';
+import { uiSectionColorblindModeOptions } from '../sections/colorblind_mode_options.js';
 
 
 export function uiPanePreferences(context) {
@@ -16,7 +16,7 @@ export function uiPanePreferences(context) {
     .sections([
       uiSectionPrivacy(context),
       uiSectionMapInteractionOptions(context),
-//      uiSectionColorSelection(context),
-//      uiSectionColorblindModeOptions(context)
+      uiSectionColorSelection(context),
+      uiSectionColorblindModeOptions(context)
     ]);
 }

--- a/modules/ui/sections/color_selection.js
+++ b/modules/ui/sections/color_selection.js
@@ -3,19 +3,18 @@ import { uiCombobox } from '../combobox.js';
 import { uiSection } from '../section.js';
 import { utilNoAuto } from '../../util/index.js';
 
-
 export function uiSectionColorSelection(context) {
   const l10n = context.systems.l10n;
-  const colors = context.systems.colors;  // todo: replace
+  const styles = context.systems.styles;
 
   // Add or replace event handlers
-  colors.off('colorsloaded', loadComboBoxData);
-  colors.on('colorsloaded', loadComboBoxData);
+  styles.off('colorsloaded', loadComboBoxData);
+  styles.on('colorsloaded', loadComboBoxData);
 
   let comboData = [];
 
   function loadComboBoxData(){
-    let colorSchemeKeys = Object.keys(colors.getAllColorSchemes());
+    let colorSchemeKeys = Object.keys(styles.getAllColorSchemes());
 
     for (let i = 0; i < colorSchemeKeys.length; i++) {
       let colorObject = {};
@@ -29,7 +28,7 @@ export function uiSectionColorSelection(context) {
 
 
   const section = uiSection(context, 'preferences-color-selection')
-    .label(l10n.tHtml('preferences.color_selection.title'))
+    .label(l10n.t('preferences.color_selection.title'))
     .disclosureContent(renderDisclosureContent);
 
   const colorCombo = uiCombobox(context, 'color-selection');
@@ -63,8 +62,8 @@ export function uiSectionColorSelection(context) {
           _colorSelectedId = val;
           let colorSchemeName = getColorSchemeName(_colorSelectedId);
 
-          if (colors.currentColorScheme !== colorSchemeName) {
-            colors.setColorScheme(colorSchemeName);
+          if (styles.currentColorScheme !== colorSchemeName) {
+            styles.setColorScheme(colorSchemeName);
             context.scene().dirtyScene();
             context.systems.map.deferredRedraw();
           }

--- a/modules/ui/sections/colorblind_mode_options.js
+++ b/modules/ui/sections/colorblind_mode_options.js
@@ -7,7 +7,7 @@ import { utilNoAuto } from '../../util/index.js';
 
 export function uiSectionColorblindModeOptions(context) {
   const l10n = context.systems.l10n;
-  const colors = context.systems.colors;  // todo: replace
+  const styles = context.systems.styles; 
 
   let comboData = [{ title: 'default', value: l10n.t('preferences.colorblind_options.default') }];
 
@@ -20,9 +20,9 @@ export function uiSectionColorblindModeOptions(context) {
   const filtersObject = { 'Protanopia': protanopiaFilter, 'Deuteranopia': deuteranopiaFilter, 'Tritanopia': tritanopiaFilter };
 
   // color matrices
-  const protanopiaMatrix = colors.protanopiaMatrix;
-  const deuteranopiaMatrix = colors.deuteranopiaMatrix;
-  const tritanopiaMatrix = colors.tritanopiaMatrix;
+  const protanopiaMatrix = styles.protanopiaMatrix;
+  const deuteranopiaMatrix = styles.deuteranopiaMatrix;
+  const tritanopiaMatrix = styles.tritanopiaMatrix;
 
   // apply color matrices to filters
   protanopiaFilter.matrix = protanopiaMatrix;
@@ -45,7 +45,7 @@ export function uiSectionColorblindModeOptions(context) {
   loadComboBoxData();
 
   const section = uiSection(context, 'preferences-colorblind-mode-options')
-    .label(l10n.tHtml('preferences.colorblind_options.title'))
+    .label(l10n.t('preferences.colorblind_options.title'))
     .disclosureContent(renderDisclosureContent);
 
   const colorblindCombo = uiCombobox(context, 'colorblind-mode-options');

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -97,7 +97,7 @@ function buildData() {
   minifySync('data/qa_data.json', 'dist/data/qa_data.min.json');
   minifySync('data/shortcuts.json', 'dist/data/shortcuts.min.json');
   minifySync('data/territory_languages.json', 'dist/data/territory_languages.min.json');
-  minifySync('data/colors.json', 'dist/data/colors.min.json')
+  minifySync('data/colors.json', 'dist/data/colors.min.json');
 
   return _currBuild = Promise.resolve(true)
     .then(() => {

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -97,6 +97,7 @@ function buildData() {
   minifySync('data/qa_data.json', 'dist/data/qa_data.min.json');
   minifySync('data/shortcuts.json', 'dist/data/shortcuts.min.json');
   minifySync('data/territory_languages.json', 'dist/data/territory_languages.min.json');
+  minifySync('data/colors.json', 'dist/data/colors.min.json')
 
   return _currBuild = Promise.resolve(true)
     .then(() => {


### PR DESCRIPTION
Add default and example color scheme objects to `colors.json`. Rename example color scheme object to `high_contrast` to reflect functionality in `colors.json` and `core.yaml`

Minify `colors.json` in `build_data.js`. Add `colors.json` to `DataLoaderSystem`'s `fileMap`.

Add color scheme helper functions to `StyleSytem`, with comments to describe each functions parameters and return values (where applicable).

Update `StyleSystem`'s `styleMatch()` function to interact with color scheme objects from `colors.json` rather than from `STYLE_DECLARATIONS`.

Fix white space discrepancies in `StyleSystem.js`.

Reduce boilerplate code and comments relating to color scheme handling in `StyleSystem.js`.

Update `color_selection.js` and `colorblind_mode_options.js` to use `StyleSystem` rather than the non-existent `ColorSystem`.

Uncomment color schemes and colorblind mode options sections in `preferences.js` to add them to the Preferences pane of the UI.

Refs: Issue #1230