### PR TITLE
Redo the maproulette task fetch / challenge deletion filtering.

### DIFF
--- a/modules/services/MapRouletteService.js
+++ b/modules/services/MapRouletteService.js
@@ -67,7 +67,6 @@ export class MapRouletteService extends AbstractSystem {
       tasks: new Map(),    // Map (taskID -> Task)
       loadedTile: {},
       inflightTile: {},
-      fetchedChallengeIds: new Set(),
       inflightPost: {},
       closed: {},
       comment: {},
@@ -155,13 +154,6 @@ export class MapRouletteService extends AbstractSystem {
           }
 
           for (const challengeId of challengeIdsToQuery) {
-            // Check if we've already fetched this challenge, perhaps even in another tile
-            if (this._cache.fetchedChallengeIds.has(challengeId)) {
-              continue;
-            }
-            // Add the challenge ID to the set of fetched challenges
-            this._cache.fetchedChallengeIds.add(challengeId);
-
             // fetch the challenge data
             fetch(`${MAPROULETTE_API}/challenge/${challengeId}`)
             .then(response => response.json())


### PR DESCRIPTION
This PR corrects the logic flaw in our task filtering. 

the flaw was that for each challenge, we'd only bother adding a single child task to the service cache, no matter how many tasks it had! 

Instead, we now do the following: 

1) Load all tasks for the tile. 
2) Create a map from parent Challenge Ids --> [list of child tasks]
3) For each challenge in the map, fetch its info (relying on browser cache to speed repeats up). 
4) If the challenge is not deleted, iterate through all its child tasks and add them to the cache. 


Here's a shortvid of what san francisco looks like before/after the fix: 

https://github.com/facebook/Rapid/assets/1887955/e5399442-3b28-49bc-9ac3-84a15a8f2643


