### PR TITLE
OSM Tag Frequency Counter for UI Color Analysis

### DIFF
--- a/data/colors.json
+++ b/data/colors.json
@@ -37,7 +37,7 @@
       "fill": { "color": "0xaaaaaa", "alpha": 0.3 }
     }
   },
-  "example": {
+  "high_contrast": {
     "red": {
       "fill": { "color": "0xFF0E41", "alpha": 0.3 }
     },

--- a/data/colors.json
+++ b/data/colors.json
@@ -1,0 +1,78 @@
+{
+  "default": {
+    "red": {
+      "fill": { "color": "0xe06e5f", "alpha": 0.3 }
+    },
+    "green": {
+      "fill": { "color": "0x8cd05f", "alpha": 0.3 }
+    },
+    "blue": {
+      "fill": { "color": "0x77d4de", "alpha": 0.3 }
+    },
+    "yellow": {
+      "fill": { "color": "0xffff94", "alpha": 0.25 }
+    },
+    "gold": {
+      "fill": { "color": "0xc4be19", "alpha": 0.3 }
+    },
+    "orange": {
+      "fill": { "color": "0xd6881a", "alpha": 0.3 }
+    },
+    "pink": {
+      "fill": { "color": "0xe3a4f5", "alpha": 0.3 }
+    },
+    "teal": {
+      "fill": { "color": "0x99e1aa", "alpha": 0.3 }
+    },
+    "lightgreen": {
+      "fill": { "color": "0xbee83f", "alpha": 0.3 }
+    },
+    "tan": {
+      "fill": { "color": "0xf5dcba", "alpha": 0.3 }
+    },
+    "darkgray": {
+      "fill": { "color": "0x8c8c8c", "alpha": 0.5 }
+    },
+    "lightgray": {
+      "fill": { "color": "0xaaaaaa", "alpha": 0.3 }
+    }
+  },
+  "example": {
+    "red": {
+      "fill": { "color": "0xFF0E41", "alpha": 0.3 }
+    },
+    "green": {
+      "fill": { "color": "0x09F04A", "alpha": 0.3 }
+    },
+    "blue": {
+      "fill": { "color": "0x0CBCFF", "alpha": 0.3 }
+    },
+    "yellow": {
+      "fill": { "color": "0xFFCA09", "alpha": 0.25 }
+    },
+    "gold": {
+      "fill": { "color": "0xFF0EBC", "alpha": 0.3 }
+    },
+    "orange": {
+      "fill": { "color": "0xFF510B", "alpha": 0.3 }
+    },
+    "pink": {
+      "fill": { "color": "0xF1C0E8", "alpha": 0.3 }
+    },
+    "teal": {
+      "fill": { "color": "0x12FFD1", "alpha": 0.3 }
+    },
+    "lightgreen": {
+      "fill": { "color": "0x540FFF", "alpha": 0.3 }
+    },
+    "tan": {
+      "fill": { "color": "0xAFFA1F", "alpha": 0.3 }
+    },
+    "darkgray": {
+      "fill": { "color": "0x0000FE", "alpha": 0.5 }
+    },
+    "lightgray": {
+      "fill": { "color": "0xE9AF1E", "alpha": 0.3 }
+    }
+  }
+}

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1022,7 +1022,7 @@ en:
       title: Map Color Scheme
       tooltip: Switch between color schemes
       default: Default
-      example: Example (High Contrast)
+      high_contrast: High Contrast
       placeholder: Select color scheme
     colorblind_options:
       title: Colorblind Mode

--- a/modules/core/DataLoaderSystem.js
+++ b/modules/core/DataLoaderSystem.js
@@ -23,6 +23,7 @@ export class DataLoaderSystem extends AbstractSystem {
 
     const fileMap  = new Map();
     fileMap.set('address_formats', 'data/address_formats.min.json');
+    fileMap.set('colors', 'data/colors.min.json');
     fileMap.set('deprecated', 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@6.6/dist/deprecated.min.json');
     fileMap.set('discarded', 'https://cdn.jsdelivr.net/npm/@openstreetmap/id-tagging-schema@6.6/dist/discarded.min.json');
     fileMap.set('imagery', 'data/imagery.min.json');

--- a/modules/core/StyleSystem.js
+++ b/modules/core/StyleSystem.js
@@ -35,8 +35,6 @@ export class StyleSystem extends AbstractSystem {
     this.context = context;
     this.dependencies = new Set(['dataloader']);
     this.autoStart = true;
-
-    // To handle color schemes
     this.colorData = null;
     this.colorSchemes = null;
     this.currentColorScheme = null;
@@ -44,24 +42,24 @@ export class StyleSystem extends AbstractSystem {
     // Experiment, see Rapid#1230
     // matrix values from https://github.com/maputnik/editor
     this.protanopiaMatrix = [
-      0.567,  0.433,  0,     0,  0,
-      0.558,  0.442,  0,     0,  0,
-      0,      0.242,  0.758, 0,  0,
-      0,      0,      0,     1,  0
+      0.567, 0.433, 0, 0, 0,
+      0.558, 0.442, 0, 0, 0,
+      0, 0.242, 0.758, 0, 0,
+      0, 0, 0, 1, 0
     ];
 
     this.deuteranopiaMatrix = [
-      0.625,  0.375,  0,     0,  0,
-      0.7,    0.3,    0,     0,  0,
-      0,      0.3,    0.7,   0,  0,
-      0,      0,      0,     1,  0
+      0.625, 0.375, 0, 0, 0,
+      0.7, 0.3, 0, 0, 0,
+      0, 0.3, 0.7, 0, 0,
+      0, 0, 0, 1, 0
     ];
 
     this.tritanopiaMatrix = [
-      0.95,   0.05,   0,     0,  0,
-      0,      0.433,  0.567, 0,  0,
-      0,      0.475,  0.525, 0,  0,
-      0,      0,      0,     1,  0
+      0.95, 0.05, 0, 0, 0,
+      0, 0.433, 0.567, 0, 0,
+      0, 0.475, 0.525, 0, 0,
+      0, 0, 0, 1, 0
     ];
 
 
@@ -184,12 +182,12 @@ export class StyleSystem extends AbstractSystem {
         stroke: { width: 3, color: 0x81d25c, dash: [3, 3], cap: 'butt' }
       },
       river: {
-        fill:   { color: 0x77d4de, alpha: 0.3 },   // rgb(119, 211, 222)
+        fill: { color: 0x77d4de, alpha: 0.3 },   // rgb(119, 211, 222)
         casing: { width: 10, color: 0x444444 },
         stroke: { width: 8, color: 0x77dddd }
       },
       stream: {
-        fill:   { color: 0x77d4de, alpha: 0.3 },   // rgb(119, 211, 222)
+        fill: { color: 0x77d4de, alpha: 0.3 },   // rgb(119, 211, 222)
         casing: { width: 7, color: 0x444444 },
         stroke: { width: 5, color: 0x77dddd }
       },
@@ -229,7 +227,7 @@ export class StyleSystem extends AbstractSystem {
         stroke: { width: 3, color: 0xdddddd, dash: [10, 5, 2, 5], cap: 'round' }
       },
       barrier_hedge: {
-        fill:   { color: 0x8cd05f, alpha: 0.3 },   // rgb(140, 208, 95)
+        fill: { color: 0x8cd05f, alpha: 0.3 },   // rgb(140, 208, 95)
         casing: { alpha: 0 },  // disable
         stroke: { width: 3, color: 0x8cd05f, dash: [10, 5, 2, 5], cap: 'round' }
       },
@@ -525,6 +523,7 @@ export class StyleSystem extends AbstractSystem {
     // To handle color schemes
     this.getColorScheme = this.getColorScheme.bind(this);
     this.getAllColorSchemes = this.getAllColorSchemes.bind(this);
+    this.setColorScheme = this.setColorScheme.bind(this);
   }
 
 
@@ -640,7 +639,7 @@ export class StyleSystem extends AbstractSystem {
           continue;
         }
 
-        matched = declaration;
+        matched = declaration || currentScheme;
         styleScore = score;
         styleKey = k;
 //        styleVal = v;
@@ -660,14 +659,14 @@ export class StyleSystem extends AbstractSystem {
         hasLifecycleTag = true;
         break;
 
-      // Lifecycle value, e.g. `railway=demolished`
-      // (applies only if `k` is styleKey or there is no styleKey controlling styling)
+        // Lifecycle value, e.g. `railway=demolished`
+        // (applies only if `k` is styleKey or there is no styleKey controlling styling)
       } else if ((!styleKey || k === styleKey) && lifecycleVals.has(v)) {
         hasLifecycleTag = true;
         break;
 
-      // Lifecycle key prefix, e.g. `demolished:railway=rail`
-      // (applies only if there is no styleKey controlling the styling)
+        // Lifecycle key prefix, e.g. `demolished:railway=rail`
+        // (applies only if there is no styleKey controlling the styling)
       } else if (!styleKey && lifecycleRegex.test(k) && v !== 'no') {
         hasLifecycleTag = true;
         break;
@@ -778,6 +777,19 @@ export class StyleSystem extends AbstractSystem {
     // This just returns the value of the tag, but ignores 'no' values
     function getTag(tags, key) {
       return tags[key] === 'no' ? undefined : tags[key];
+    }
+  }
+
+  // Returns object containing all color scheme objects
+  getAllColorSchemes() {
+    return this.STYLE_SCHEMES;
+  }
+
+  // Sets map color scheme
+  setColorScheme(schemeName) {
+    let currentScheme = this.STYLE_SCHEMES[schemeName];
+    if (this.currentColorScheme !== currentScheme) {
+      this.currentColorScheme = currentScheme;
     }
   }
 }

--- a/modules/core/StyleSystem.js
+++ b/modules/core/StyleSystem.js
@@ -35,7 +35,6 @@ export class StyleSystem extends AbstractSystem {
     this.context = context;
     this.dependencies = new Set(['dataloader']);
     this.autoStart = true;
-    this.colorData = null;
     this.colorSchemes = null;
     this.currentColorScheme = null;
 
@@ -519,8 +518,6 @@ export class StyleSystem extends AbstractSystem {
 
 
     this.styleMatch = this.styleMatch.bind(this);
-
-    // To handle color schemes
     this.getColorScheme = this.getColorScheme.bind(this);
     this.getAllColorSchemes = this.getAllColorSchemes.bind(this);
     this.setColorScheme = this.setColorScheme.bind(this);
@@ -549,17 +546,16 @@ export class StyleSystem extends AbstractSystem {
   startAsync() {
     this._started = true;
 
-    // To handle color schemes
+    // Fetch the color scheme objects from colors.json
     const context = this.context;
     const dataloader = context.systems.dataloader;
 
     dataloader.getDataAsync('colors')
       .then((data) => {
         this.colorSchemes = data;
-        // set current scheme to default
-        this.colorData = data.default;
-        this.currentColorScheme = 'default';
-        this.emit('colorsloaded');  // emit copies
+        // Set the current color scheme to default
+        this.currentColorScheme = data.default;
+        this.emit('colorsloaded');
       });
 
     return Promise.resolve();
@@ -580,7 +576,7 @@ export class StyleSystem extends AbstractSystem {
    * @return {Object}  Default color scheme object
    */
   getColorScheme() {
-    return this.colorData;
+    return this.currentColorScheme;
   }
 
   /**
@@ -593,14 +589,13 @@ export class StyleSystem extends AbstractSystem {
 
   /**
    * setColorScheme
-   * Assigns the colorData var to the new scheme, if the selected scheme is not the current scheme
+   * Assigns the currentColorScheme var to the new scheme, if the selected scheme is not the current scheme
    * @param  {Object}  scheme - color scheme project
    */
   setColorScheme(scheme) {
     let currentScheme = this.colorSchemes[scheme];
-    if (this.colorData !== currentScheme) { 
-      this.currentColorScheme = scheme;
-      this.colorData = currentScheme;
+    if (this.currentColorScheme !== currentScheme) { 
+      this.currentColorScheme = currentScheme;
     }
   }
 

--- a/modules/core/StyleSystem.js
+++ b/modules/core/StyleSystem.js
@@ -36,6 +36,11 @@ export class StyleSystem extends AbstractSystem {
     this.dependencies = new Set(['dataloader']);
     this.autoStart = true;
 
+    // To handle color schemes
+    this.colorData = null;
+    this.colorSchemes = null;
+    this.currentColorScheme = null;
+
     // Experiment, see Rapid#1230
     // matrix values from https://github.com/maputnik/editor
     this.protanopiaMatrix = [
@@ -96,43 +101,6 @@ export class StyleSystem extends AbstractSystem {
       LIFECYCLE: {   // e.g. planned, proposed, abandoned, disused, razed
         casing: { alpha: 0 },  // disable
         stroke: { dash: [7, 3], cap: 'butt' }
-      },
-
-      red: {
-        fill: { color: 0xe06e5f, alpha: 0.3 }   // rgb(224, 110, 95)
-      },
-      green: {
-        fill: { color: 0x8cd05f, alpha: 0.3 }   // rgb(140, 208, 95)
-      },
-      blue: {
-        fill: { color: 0x77d4de, alpha: 0.3 }   // rgb(119, 211, 222)
-      },
-      yellow: {
-        fill: { color: 0xffff94, alpha: 0.25 }  // rgb(255, 255, 148)
-      },
-      gold: {
-        fill: { color: 0xc4be19, alpha: 0.3 }   // rgb(196, 189, 25)
-      },
-      orange: {
-        fill: { color: 0xd6881a, alpha: 0.3 }   // rgb(214, 136, 26)
-      },
-      pink: {
-        fill: { color: 0xe3a4f5, alpha: 0.3 }   // rgb(228, 164, 245)
-      },
-      teal: {
-        fill: { color: 0x99e1aa, alpha: 0.3 }   // rgb(153, 225, 170)
-      },
-      lightgreen: {
-        fill: { color: 0xbee83f, alpha: 0.3 }   // rgb(191, 232, 63)
-      },
-      tan: {
-        fill: { color: 0xf5dcba, alpha: 0.3 }   // rgb(245, 220, 186)
-      },
-      darkgray: {
-        fill: { color: 0x8c8c8c, alpha: 0.5 }   // rgb(140, 140, 140)
-      },
-      lightgray: {
-        fill: { color: 0xaaaaaa, alpha: 0.3 }   // rgb(170, 170, 170)
       },
 
       motorway: {
@@ -226,7 +194,7 @@ export class StyleSystem extends AbstractSystem {
         stroke: { width: 5, color: 0x77dddd }
       },
       ridge: {
-        stroke: { width: 2, color: 0x8cd05f}  // rgb(140, 208, 95)
+        stroke: { width: 2, color: 0x8cd05f }  // rgb(140, 208, 95)
       },
       runway: {
         casing: { width: 10, color: 0x000000, cap: 'butt' },
@@ -270,7 +238,7 @@ export class StyleSystem extends AbstractSystem {
         stroke: { width: 5, color: 0x8cd05f }
       },
       construction: {
-        casing: { width: 10, color: 0xffffff},
+        casing: { width: 10, color: 0xffffff },
         stroke: { width: 8, color: 0xfc6c14, dash: [10, 10], cap: 'butt' }
       },
       pipeline: {
@@ -553,6 +521,10 @@ export class StyleSystem extends AbstractSystem {
 
 
     this.styleMatch = this.styleMatch.bind(this);
+
+    // To handle color schemes
+    this.getColorScheme = this.getColorScheme.bind(this);
+    this.getAllColorSchemes = this.getAllColorSchemes.bind(this);
   }
 
 
@@ -561,10 +533,10 @@ export class StyleSystem extends AbstractSystem {
    * Called after all core objects have been constructed.
    * @return {Promise} Promise resolved when this component has completed initialization
    */
-  initAsync(){
+  initAsync() {
     for (const id of this.dependencies) {
       if (!this.context.systems[id]) {
-          return Promise.reject(`Cannot init: ${this.id} requires ${id}`);
+        return Promise.reject(`Cannot init: ${this.id} requires ${id}`);
       }
     }
     return Promise.resolve();
@@ -577,6 +549,20 @@ export class StyleSystem extends AbstractSystem {
    */
   startAsync() {
     this._started = true;
+
+    // To handle color schemes
+    const context = this.context;
+    const dataloader = context.systems.dataloader;
+
+    dataloader.getDataAsync('colors')
+      .then((data) => {
+        this.colorSchemes = data;
+        // set current scheme to default
+        this.colorData = data.default;
+        this.currentColorScheme = 'default';
+        this.emit('colorsloaded');  // emit copies
+      });
+
     return Promise.resolve();
   }
 
@@ -590,6 +576,34 @@ export class StyleSystem extends AbstractSystem {
     return Promise.resolve();
   }
 
+  /**
+   * getColorScheme
+   * @return {Object}  Default color scheme object
+   */
+  getColorScheme() {
+    return this.colorData;
+  }
+
+  /**
+   * getAllColorSchemeas
+   * @return {Object}  All color scheme objects
+   */
+  getAllColorSchemes() {
+    return this.colorSchemes;
+  }
+
+  /**
+   * setColorScheme
+   * Assigns the colorData var to the new scheme, if the selected scheme is not the current scheme
+   * @param  {Object}  scheme - color scheme project
+   */
+  setColorScheme(scheme) {
+    let currentScheme = this.colorSchemes[scheme];
+    if (this.colorData !== currentScheme) { 
+      this.currentColorScheme = scheme;
+      this.colorData = currentScheme;
+    }
+  }
 
   /**
    * styleMatch
@@ -604,7 +618,8 @@ export class StyleSystem extends AbstractSystem {
 // eventually expose this to the caller?
 // it may be useful to know what `k=v` pair matched
     let styleKey;           // the key controlling the styling, if any
-//    let styleVal;           // the value controlling the styling, if any
+    let styleVal;           // the value controlling the styling, if any
+    let colorScheme = this.getColorScheme();
 
     // First, match the tags to the best matching `styleID`..
     for (const [k, v] of Object.entries(tags)) {
@@ -619,7 +634,7 @@ export class StyleSystem extends AbstractSystem {
       if (lifecycleVals.has(v)) score = 999;         // exception: lifecycle values
 
       if (styleID && score <= styleScore) {
-        const declaration = this.STYLE_DECLARATIONS[styleID];
+        const declaration = this.STYLE_DECLARATIONS[styleID] || colorScheme[styleID];
         if (!declaration) {
           console.error(`invalid styleID: ${styleID}`);  // eslint-disable-line
           continue;

--- a/modules/ui/panes/preferences.js
+++ b/modules/ui/panes/preferences.js
@@ -1,8 +1,8 @@
 import { uiPane } from '../pane.js';
 import { uiSectionPrivacy } from '../sections/privacy.js';
-//import { uiSectionColorSelection } from '../sections/color_selection.js';
-//import { uiSectionColorblindModeOptions } from '../sections/colorblind_mode_options.js';
 import { uiSectionMapInteractionOptions } from '../sections/map_interaction_options.js';
+import { uiSectionColorSelection } from '../sections/color_selection.js';
+import { uiSectionColorblindModeOptions } from '../sections/colorblind_mode_options.js';
 
 
 export function uiPanePreferences(context) {
@@ -16,7 +16,7 @@ export function uiPanePreferences(context) {
     .sections([
       uiSectionPrivacy(context),
       uiSectionMapInteractionOptions(context),
-//      uiSectionColorSelection(context),
-//      uiSectionColorblindModeOptions(context)
+      uiSectionColorSelection(context),
+      uiSectionColorblindModeOptions(context)
     ]);
 }

--- a/modules/ui/sections/color_selection.js
+++ b/modules/ui/sections/color_selection.js
@@ -26,6 +26,7 @@ export function uiSectionColorSelection(context) {
     return comboData;
   }
 
+  comboData = loadComboBoxData();
 
   const section = uiSection(context, 'preferences-color-selection')
     .label(l10n.t('preferences.color_selection.title'))

--- a/modules/ui/sections/color_selection.js
+++ b/modules/ui/sections/color_selection.js
@@ -3,19 +3,18 @@ import { uiCombobox } from '../combobox.js';
 import { uiSection } from '../section.js';
 import { utilNoAuto } from '../../util/index.js';
 
-
 export function uiSectionColorSelection(context) {
   const l10n = context.systems.l10n;
-  const colors = context.systems.colors;  // todo: replace
+  const styles = context.systems.styles;
 
   // Add or replace event handlers
-  colors.off('colorsloaded', loadComboBoxData);
-  colors.on('colorsloaded', loadComboBoxData);
+  styles.off('colorsloaded', loadComboBoxData);
+  styles.on('colorsloaded', loadComboBoxData);
 
   let comboData = [];
 
   function loadComboBoxData(){
-    let colorSchemeKeys = Object.keys(colors.getAllColorSchemes());
+    let colorSchemeKeys = Object.keys(styles.getAllColorSchemes());
 
     for (let i = 0; i < colorSchemeKeys.length; i++) {
       let colorObject = {};
@@ -29,7 +28,7 @@ export function uiSectionColorSelection(context) {
 
 
   const section = uiSection(context, 'preferences-color-selection')
-    .label(l10n.tHtml('preferences.color_selection.title'))
+    .label(l10n.t('preferences.color_selection.title'))
     .disclosureContent(renderDisclosureContent);
 
   const colorCombo = uiCombobox(context, 'color-selection');
@@ -63,8 +62,8 @@ export function uiSectionColorSelection(context) {
           _colorSelectedId = val;
           let colorSchemeName = getColorSchemeName(_colorSelectedId);
 
-          if (colors.currentColorScheme !== colorSchemeName) {
-            colors.setColorScheme(colorSchemeName);
+          if (styles.currentColorScheme !== colorSchemeName) {
+            styles.setColorScheme(colorSchemeName);
             context.scene().dirtyScene();
             context.systems.map.deferredRedraw();
           }

--- a/modules/ui/sections/colorblind_mode_options.js
+++ b/modules/ui/sections/colorblind_mode_options.js
@@ -29,7 +29,7 @@ export function uiSectionColorblindModeOptions(context) {
   deuteranopiaFilter.matrix = deuteranopiaMatrix;
   tritanopiaFilter.matrix = tritanopiaMatrix;
 
-  function loadComboBoxData(){
+  function loadComboBoxData() {
     let colorblindModes = Object.keys(filtersObject);
 
     for (let i = 0; i < colorblindModes.length; i++) {

--- a/modules/ui/sections/colorblind_mode_options.js
+++ b/modules/ui/sections/colorblind_mode_options.js
@@ -7,7 +7,7 @@ import { utilNoAuto } from '../../util/index.js';
 
 export function uiSectionColorblindModeOptions(context) {
   const l10n = context.systems.l10n;
-  const colors = context.systems.colors;  // todo: replace
+  const styles = context.systems.styles; 
 
   let comboData = [{ title: 'default', value: l10n.t('preferences.colorblind_options.default') }];
 
@@ -20,9 +20,9 @@ export function uiSectionColorblindModeOptions(context) {
   const filtersObject = { 'Protanopia': protanopiaFilter, 'Deuteranopia': deuteranopiaFilter, 'Tritanopia': tritanopiaFilter };
 
   // color matrices
-  const protanopiaMatrix = colors.protanopiaMatrix;
-  const deuteranopiaMatrix = colors.deuteranopiaMatrix;
-  const tritanopiaMatrix = colors.tritanopiaMatrix;
+  const protanopiaMatrix = styles.protanopiaMatrix;
+  const deuteranopiaMatrix = styles.deuteranopiaMatrix;
+  const tritanopiaMatrix = styles.tritanopiaMatrix;
 
   // apply color matrices to filters
   protanopiaFilter.matrix = protanopiaMatrix;
@@ -45,7 +45,7 @@ export function uiSectionColorblindModeOptions(context) {
   loadComboBoxData();
 
   const section = uiSection(context, 'preferences-colorblind-mode-options')
-    .label(l10n.tHtml('preferences.colorblind_options.title'))
+    .label(l10n.t('preferences.colorblind_options.title'))
     .disclosureContent(renderDisclosureContent);
 
   const colorblindCombo = uiCombobox(context, 'colorblind-mode-options');

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -99,7 +99,7 @@ function buildData() {
   minifySync('data/qa_data.json', 'dist/data/qa_data.min.json');
   minifySync('data/shortcuts.json', 'dist/data/shortcuts.min.json');
   minifySync('data/territory_languages.json', 'dist/data/territory_languages.min.json');
-  minifySync('data/colors.json', 'dist/data/colors.min.json')
+  minifySync('data/colors.json', 'dist/data/colors.min.json');
 
   return _currBuild = Promise.resolve(true)
     .then(() => {

--- a/scripts/build_data.js
+++ b/scripts/build_data.js
@@ -99,6 +99,7 @@ function buildData() {
   minifySync('data/qa_data.json', 'dist/data/qa_data.min.json');
   minifySync('data/shortcuts.json', 'dist/data/shortcuts.min.json');
   minifySync('data/territory_languages.json', 'dist/data/territory_languages.min.json');
+  minifySync('data/colors.json', 'dist/data/colors.min.json')
 
   return _currBuild = Promise.resolve(true)
     .then(() => {


### PR DESCRIPTION
# OSM Tag Frequency Counter for UI Color Analysis

**TL;DR**
I used empirical analysis to identify the most relevant colors on the map for the purpose of creating colorblind-friendly map color schemes. 

## Overview
In order to create data-informed colorblind-friendly color schemes for the map, I measured the frequency of OSM tags rendered within a specific map extent.

This PR includes code incorporated from #1365. However, the main contribution of this PR is the chunk of code in `/modules/pixi/PixiLayerOsm.js` which does the OSM tag counting. This code was instrumental in #1384, specifically in the creation of three (3) colorblind-friendly color schemes. 

_**NOTE**: For the most part, this conversation is going to be held independent of the color system proposed in #1384_ 

## Thought Process Summary
Rapid has **39** distinct HEX colors referenced in `/modules/core/StyleSystem.js` and `/data/colors.js`. The aim is create colorblind-friendly color schemes in which:
- All colors are colorblind-accessible
- All color interactions are colorblind-accessible

One approach to this would be to create new color schemes which replace all 39 colors while ensuring the two conditions listed above.

A much simpler approach would be to focus on 5-10 colors which are most relevant to a colorblind user. That is what this PR addresses. The core question being asked is:

> **"How does one identify the most relevant colors on the map?"**

## Approaches
This section covers three potential approaches to answering the question above. Approaches no. 1 and no. 2 were attempted in the course of this PR. Approach no. 3 was not attempted due to the amount of resources and time it would require.

These approaches are NOT conclusive (hence the **ISSUE**s highlighted) and can be built upon further.

### Approach no. 1
"How many times is each color referred to in the StyleSystem.js file?" 

**PROCESS**: Use the file search function in whatever file editor being used

**ISSUE**: Does not account for how often that specific definition is rendered on the map e.g. `red` is only referred to once in `StyleSystem.js` but the feature that uses it (building) occurs the most on the map (specific to the evaluation map location)

### Approach no. 2
Builds on Approach no. 1 by asking: "How many times is each OSM tag and value RENDERED?"

**PROCESS**: Programmatically count during the `render()` function call in `/modules/pixi/PixiLayerOsm.js` and print the results in console

**ISSUE**: Does not account for how features change across the map with changes in location and zoom level. >>> **NOTE**: One cannot evaluate the entire map at once because Render only renders the features (areas/polygons, lines and points) at a certain zoom level

### Approach no. 3
Builds on Approach no. 2 by asking: "How many times is each OSM tag and value rendered ACROSS THE ENTIRE MAP?"

**PROCESS**: Move across the map in tiles/extents at every possible zoom and evaluate at every possible location >> Very rigorous, very time-consuming

**ISSUE**:  Does not account for the relative size of the feature being rendered e.g. `building` is the OSM tag rendered the most BUT features like `highway` get rendered a lot bigger and take up more visual space

## Results and Implications
This section is based on the data gathered in Approach no. 2. The frequency counter code chunk is dependent on the `entities` rendered in the current map extent (as specified in the URL used).

### Research Context and Results
* Map extent: `map=15.53/6.6005/3.3352`
* URL: http://127.0.0.1:8080/#background=Bing&datasets=fbRoads,msBuildings&disable_features=boundaries&map=15.53/6.6005/3.3352
* Console Output: 
![Console Output](https://github.com/facebook/Rapid/assets/56834523/691dc74b-d1c1-4cd8-9640-ff8bfa19c951)
* Link to Data + Sheet Descriptions: https://docs.google.com/spreadsheets/d/1M56K55LK4txRY_y68z0EESOMRL_y0974CLEvssZ4h3A/edit?usp=sharing
	* STYLE_SELECTOR Frequency (Specific): Contains the loaded `STYLE_SELECTORS` (osmkey and osmvalue), how many times each osmvalue was loaded, its assigned `styleID`, the color definitions attached to said `styleID` and previews of the defined colors (**MOST IMPORTANT !!**)
	* Color Definition (direct): Contains every hardcoded color value, the `STYLE_DECLARATIONS` in which it is used and how many times it is used
	* Color Definition (colors.json): Contains every color value defined by colors.json, the STYLE_SELECTORS in which it is used and how many times it is used

### Research Implications
Based on the data gathered, I identified the 4 or 5 most frequently-used colors which heavily impacted accessibility. These identifications were further backed by visual confirmation using the colorblind emulators incorporated from #1365.

Once these colors were identified, the initial question - "How does one identify the most relevant colors on the map?" - was considered answered. You can check out the `/data/color_schemes.json` file in #1384 to see how these identified colors were redefined.