### PR TITLE
Retain multi-selection when SHIFT key is held down

### DIFF
--- a/modules/behaviors/SelectBehavior.js
+++ b/modules/behaviors/SelectBehavior.js
@@ -337,7 +337,7 @@ export class SelectBehavior extends AbstractBehavior {
     // Clicked on nothing
     if (!data) {
       context.systems.photos.selectPhoto(null);
-      if (context.mode?.id !== 'browse' && !this._multiSelection.size) {
+      if (context.mode?.id !== 'browse' && !isMultiselect) {
         context.enter('browse');
       }
       return;

--- a/modules/behaviors/SelectBehavior.js
+++ b/modules/behaviors/SelectBehavior.js
@@ -337,7 +337,7 @@ export class SelectBehavior extends AbstractBehavior {
     // Clicked on nothing
     if (!data) {
       context.systems.photos.selectPhoto(null);
-      if (context.mode?.id !== 'browse' && !isMultiselect) {
+      if (context.mode?.id !== 'browse' && !this._multiSelection.size && !isMultiselect) {
         context.enter('browse');
       }
       return;


### PR DESCRIPTION
Fixes #1071 and Fixes #1137 which are issues with the multi-selection. Previously, if a user was holding down the SHIFT key to select multiple entity and clicked on an area without an entity, all selected entities would be deselected, even though the SHIFT key was still being held down.

With this fix, the selected entities will remain selected as long as the SHIFT key is held down, regardless of where the user clicks.

1. **Before**



https://github.com/facebook/Rapid/assets/49957271/24c16465-f6c8-42cd-8b40-85393b2e2c43




2. **After**



https://github.com/facebook/Rapid/assets/49957271/e5a01b77-b677-4151-9d34-27c09dad5c08



