### PR TITLE
Update getData Method to Filter Non-visible Tasks with ChallengeID

### DIFF
--- a/modules/services/MapRouletteService.js
+++ b/modules/services/MapRouletteService.js
@@ -103,8 +103,7 @@ export class MapRouletteService extends AbstractSystem {
     const extent = this.context.viewport.visibleExtent();
     return this._cache.rbush.search(extent.bbox())
       .map(d => d.data)
-      .filter(task => !this._challengeID || task.parentId === this._challengeID)
-      .filter(task => task.isVisible);
+      .filter(task => (this._challengeID && task.parentId === this._challengeID) || (!this._challengeID && task.isVisible));
   }
 
 


### PR DESCRIPTION
Updates the `getData` method to show non-visible tasks only when a specific `challengeID` is given. 
Fixes #1436 

- **Only shows visible challenges** 
![May 21 Screenshot optimized (2)](https://github.com/facebook/Rapid/assets/49957271/2540aa8a-f2e7-43a6-b378-465b6b20a8b0)
- **Enter challengeId of an invisible challenge** 
![May 21 Screenshot optimized (3)](https://github.com/facebook/Rapid/assets/49957271/8d3c5649-b4e3-4206-b0b5-856c5b8c742b)
