### PR TITLE
Create new dataset for Meta Footways in the Rapid Service.

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1145,6 +1145,9 @@ en:
     fbRoads:
       label: Facebook Roads
       license_markdown: "[license](https://rapideditor.org/doc/license/MapWithAILicense.pdf)"
+    metaFootways:
+      label: Meta Footways
+      license_markdown: "[license](https://rapideditor.org/doc/license/MapWithAILicense.pdf)"
     msBuildings:
       label: Microsoft Buildings
       license_markdown: "[license](https://github.com/microsoft/USBuildingFootprints/blob/master/LICENSE-DATA)"

--- a/modules/core/RapidSystem.js
+++ b/modules/core/RapidSystem.js
@@ -110,6 +110,19 @@ export class RapidSystem extends AbstractSystem {
           label: l10n.t('rapid_feature_toggle.msBuildings.label'),
           license_markdown: l10n.t('rapid_feature_toggle.msBuildings.license_markdown')
         });
+
+        this._datasets.set('metaFootways', {
+          id: 'metaFootways',
+          beta: true,
+          added: true,         // whether it should appear in the list
+          enabled: false,      // whether the user has checked it on
+          conflated: true,
+          service: 'mapwithai',
+          color: RAPID_MAGENTA,
+          dataUsed: ['mapwithai', 'Meta Footways'],
+          label: l10n.t('rapid_feature_toggle.metaFootways.label'),
+          license_markdown: l10n.t('rapid_feature_toggle.metaFootways.license_markdown')
+        });
       });
   }
 

--- a/modules/pixi/PixiLayerRapid.js
+++ b/modules/pixi/PixiLayerRapid.js
@@ -214,7 +214,7 @@ export class PixiLayerRapid extends AbstractLayer {
 
       // fb_ai service gives us roads and buildings together,
       // so filter further according to which dataset we're drawing
-      if (dataset.id === 'fbRoads' || dataset.id === 'rapid_intro_graph') {
+      if (dataset.id === 'fbRoads' || dataset.id === 'metaFootways' || dataset.id === 'rapid_intro_graph') {
         data.lines = entities.filter(d => d.geometry(dsGraph) === 'line' && !!d.tags.highway);
 
         // Gather endpoint vertices, we will render these also

--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -253,10 +253,12 @@ export class MapWithAIService extends AbstractSystem {
     if (datasetID === 'fbRoads') {
       qs.result_type = 'road_vector_xml';
 
+    } else if (datasetID === 'metaFootways') {
+      qs.result_type = 'extended_osc';
+      qs.sources = 'ML2OSM_META_FOOTWAYS';
     } else if (datasetID === 'msBuildings') {
       qs.result_type = 'road_building_vector_xml';
       qs.building_source = 'microsoft';
-
     } else {
       qs.result_type = 'osm_xml';
       qs.sources = `esri_building.${datasetID}`;

--- a/package.json
+++ b/package.json
@@ -143,6 +143,6 @@
     "> 0.2%, last 3 major versions, Firefox ESR, maintained node versions"
   ],
   "volta": {
-    "node": "18.18"
+    "node": "18.19.1"
   }
 }


### PR DESCRIPTION
This PR introduces the 'meta footways' dataset to the Rapid button in preview mode. 

![image](https://github.com/facebook/Rapid/assets/1887955/bdf9542d-4eb0-4467-8710-271bd7ef4dba)

There's not a lot of code here as most of the real work is being done by the backend conflation service to fetch these geometries.  