### PR TITLE
create customizable zoomRange for loading imagery with a small max zoom level

### DIFF
--- a/modules/core/lib/ImagerySource.js
+++ b/modules/core/lib/ImagerySource.js
@@ -40,6 +40,7 @@ export class ImagerySource {
     this.tileSize = src.tileSize || 256;
     this.type = src.type;
     this.zoomExtent = src.zoomExtent || [0, 22];
+    this.zoomRange = src.zoomRange || 5;
 
     this.isBlocked = false;
     this.offset = [0, 0];

--- a/modules/pixi/PixiLayerBackgroundTiles.js
+++ b/modules/pixi/PixiLayerBackgroundTiles.js
@@ -161,7 +161,7 @@ export class PixiLayerBackgroundTiles extends AbstractLayer {
     // including any zoomed out tiles if this field contains any holes
     const needTiles = new Map();                // Map(tileID -> tile)
     const maxZoom = Math.ceil(z);               // the zoom we want (round up for sharper imagery)
-    const minZoom = Math.max(0, maxZoom - 5);   // the mininimum zoom we'll accept
+    const minZoom = Math.max(0, maxZoom - source.zoomRange);   // the mininimum zoom we'll accept
 
     let covered = false;
     for (let tryZoom = maxZoom; !covered && tryZoom >= minZoom; tryZoom--) {

--- a/scripts/update_imagery.js
+++ b/scripts/update_imagery.js
@@ -158,6 +158,10 @@ for (const [sourceID, source] of sources) {
     ];
   }
 
+  if (source.zoomRange) {
+    item.zoomRange = source.zoomRange;
+  }
+
   if (extent.polygon) {
     item.polygon = extent.polygon;
   } else if (extent.bbox) {


### PR DESCRIPTION
fixes #1481 by removing the hardcoded 5 zoom limit with a configurable one with a default of 5