### PR TITLE
Add Keyboard Shortcuts for Mapillary, Bing Streetside, and Kartaview

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2615,7 +2615,7 @@ en:
         minimap: "Toggle minimap"
         3dmap: "Toggle 3D map"
         mapillary: "Toggle Mapillary"
-        bringStreetside: "Toggle Bing Streetside"
+        bingStreetside: "Toggle Bing Streetside"
         kartaview: "Toggle Kartaview"
       info:
         title: "Information"

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2614,6 +2614,9 @@ en:
         title: "Viewers"
         minimap: "Toggle minimap"
         3dmap: "Toggle 3D map"
+        mapillary: "Toggle Mapillary"
+        bringStreetside: "Toggle Bing Streetside"
+        kartaview: "Toggle Kartaview"
       info:
         title: "Information"
         all: "Toggle all information panels"

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -3221,7 +3221,7 @@
           "minimap": "Toggle minimap",
           "3dmap": "Toggle 3D map",
           "mapillary": "Toggle Mapillary",
-          "bringStreetside": "Toggle Bing Streetside",
+          "bingStreetside": "Toggle Bing Streetside",
           "kartaview": "Toggle Kartaview"
         },
         "info": {

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -3219,7 +3219,10 @@
         "viewers": {
           "title": "Viewers",
           "minimap": "Toggle minimap",
-          "3dmap": "Toggle 3D map"
+          "3dmap": "Toggle 3D map",
+          "mapillary": "Toggle Mapillary",
+          "bringStreetside": "Toggle Bing Streetside",
+          "kartaview": "Toggle Kartaview"
         },
         "info": {
           "title": "Information",

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -386,6 +386,21 @@
               "rapid": true
             },
             {
+              "modifiers": ["⇧"],
+              "shortcuts": ["M"],
+              "text": "shortcuts.tools.viewers.mapillary"
+            },
+            { 
+              "modifiers": ["⇧"],
+              "shortcuts": ["S"],
+              "text": "shortcuts.tools.viewers.bringStreetside"
+            },
+            {
+              "modifiers": ["⇧"],
+              "shortcuts": ["K"],
+              "text": "shortcuts.tools.viewers.kartaview"
+            },
+            {
               "section": "info",
               "text": "shortcuts.tools.info.title"
             },

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -393,7 +393,7 @@
             { 
               "modifiers": ["⇧"],
               "shortcuts": ["S"],
-              "text": "shortcuts.tools.viewers.bringStreetside"
+              "text": "shortcuts.tools.viewers.bingStreetside"
             },
             {
               "modifiers": ["⇧"],

--- a/modules/core/PhotoSystem.js
+++ b/modules/core/PhotoSystem.js
@@ -45,6 +45,7 @@ export class PhotoSystem extends AbstractSystem {
     this._hashchange = this._hashchange.bind(this);
     this._layerchange = this._layerchange.bind(this);
     this._photoChanged = this._photoChanged.bind(this);
+    this._keydown = this._keydown.bind(this);
   }
 
 
@@ -78,7 +79,47 @@ export class PhotoSystem extends AbstractSystem {
         // Setup event handlers..
         urlhash.on('hashchange', this._hashchange);
         gfx.scene.on('layerchange', this._layerchange);
+        document.addEventListener('keydown', this._keydown);
       });
+  }
+
+
+  /**
+   * _keydown
+   * Handles keydown events to toggle photo layers.
+   * @param {KeyboardEvent} e - The keyboard event.
+   */
+  _keydown(e) {
+    if (e.shiftKey && e.key === 'M') {
+      e.preventDefault();
+      this.toggleLayer('mapillary');
+    } else if (e.shiftKey && e.key === 'S') {
+      e.preventDefault();
+      this.toggleLayer('streetside');
+    } else if (e.shiftKey && e.key === 'K') {
+      e.preventDefault();
+      this.toggleLayer('kartaview');
+    }
+  }
+
+
+  /**
+   * toggleLayer
+   * Toggles the specified photo layer on or off.
+   * @param {string} layerID - The ID of the layer to toggle.
+   */
+  toggleLayer(layerID) {
+    const scene = this.context.systems.gfx.scene;
+    const layer = scene.layers.get(layerID);
+    if (layer) {
+      layer.enabled = !layer.enabled;
+      this._photoChanged();
+      if (layer.enabled) {
+        this.selectPhoto(layerID);
+      } else {
+        this.selectPhoto(); // Deselect if turned off
+      }
+    }
   }
 
 

--- a/modules/core/PhotoSystem.js
+++ b/modules/core/PhotoSystem.js
@@ -79,7 +79,22 @@ export class PhotoSystem extends AbstractSystem {
         // Setup event handlers..
         urlhash.on('hashchange', this._hashchange);
         gfx.scene.on('layerchange', this._layerchange);
-        document.addEventListener('keydown', this._keydown);
+        const wireframeKey = '⇧M';
+        const toggleOsmKey = '⇧S';
+        const toggleNotesKey = '⇧K';
+        context.keybinding()
+        .on(wireframeKey, e => {
+          e.preventDefault();
+          this.toggleLayer('mapillary');
+        })
+        .on(toggleOsmKey, e => {
+          e.preventDefault();
+          this.toggleLayer('streetside');
+        })
+        .on(toggleNotesKey, e => {
+          e.preventDefault();
+          this.toggleLayer('kartaview');
+        });
       });
   }
 


### PR DESCRIPTION
Introduces new keyboard shortcuts for streetview imagery:

- Shift+M: Toggle Mapillary
- Shift+S: Toggle Bing Streetside
- Shift+K: Toggle Kartaview

closes #1578