### PR TITLE
Add Keyboard Shortcut for Toggling All Photo Layers

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2622,6 +2622,7 @@ en:
         mapillary: "Toggle Mapillary"
         bingStreetside: "Toggle Bing Streetside"
         kartaview: "Toggle Kartaview"
+        allDataLayers: "Toggle all data layers"
       info:
         title: "Information"
         all: "Toggle all information panels"

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -3228,7 +3228,8 @@
           "3dmap": "Toggle 3D map",
           "mapillary": "Toggle Mapillary",
           "bingStreetside": "Toggle Bing Streetside",
-          "kartaview": "Toggle Kartaview"
+          "kartaview": "Toggle Kartaview",
+          "allDataLayers": "Toggle all data layers"
         },
         "info": {
           "title": "Information",

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -401,6 +401,11 @@
               "text": "shortcuts.tools.viewers.kartaview"
             },
             {
+              "modifiers": ["⇧"],
+              "shortcuts": ["D"],
+              "text": "shortcuts.tools.viewers.allDataLayers"
+            },
+            {
               "section": "info",
               "text": "shortcuts.tools.info.title"
             },

--- a/modules/core/PhotoSystem.js
+++ b/modules/core/PhotoSystem.js
@@ -82,6 +82,7 @@ export class PhotoSystem extends AbstractSystem {
         const wireframeKey = '⇧M';
         const toggleOsmKey = '⇧S';
         const toggleNotesKey = '⇧K';
+        const toggleAllLayersKey = '⇧D';
         context.keybinding()
         .on(wireframeKey, e => {
           e.preventDefault();
@@ -94,6 +95,10 @@ export class PhotoSystem extends AbstractSystem {
         .on(toggleNotesKey, e => {
           e.preventDefault();
           this.toggleLayer('kartaview');
+        })
+        .on(toggleAllLayersKey, e => {
+          e.preventDefault();
+          this.toggleAllLayers();
         });
       });
   }
@@ -115,6 +120,26 @@ export class PhotoSystem extends AbstractSystem {
       e.preventDefault();
       this.toggleLayer('kartaview');
     }
+  }
+
+
+  /**
+   * toggleAllLayers
+   * Toggles all photo layers on or off.
+   */
+  toggleAllLayers() {
+    const scene = this.context.systems.gfx.scene;
+    const allEnabled = this.layerIDs.every(layerID => {
+      const layer = scene.layers.get(layerID);
+      return layer && layer.enabled;
+    });
+    for (const layerID of this.layerIDs) {
+      const layer = scene.layers.get(layerID);
+      if (layer) {
+        layer.enabled = !allEnabled;
+      }
+    }
+    this._photoChanged();
   }
 
 


### PR DESCRIPTION
### Summary
This pull request introduces a new feature that allows users to toggle all photo layers on and off using the `Shift + D` keyboard shortcut.
### Changes
- Added a new method `toggleAllLayers` in the `PhotoSystem` class to handle the toggling of all layers.
- Updated the `initAsync` method to bind the `Shift + D` shortcut to the `toggleAllLayers` function.
- Added shortcuts to shortcuts modal

### Issue
This PR closes issue #1594

### Testing
- Verified that pressing `Shift + D` toggles all layers on and off as expected.
- Ensured that individual layer toggling with `Shift + M`, `Shift + S`, and `Shift + K` remains functional.