### PR TITLE
Add Shift+D shortcut to toggle all data layers

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2625,6 +2625,7 @@ en:
         mapillary: "Toggle Mapillary"
         bingStreetside: "Toggle Bing Streetside"
         kartaview: "Toggle Kartaview"
+        disableDataLayers: "Toggle all data layers"
       info:
         title: "Information"
         all: "Toggle all information panels"

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -3232,7 +3232,8 @@
           "3dmap": "Toggle 3D map",
           "mapillary": "Toggle Mapillary",
           "bingStreetside": "Toggle Bing Streetside",
-          "kartaview": "Toggle Kartaview"
+          "kartaview": "Toggle Kartaview",
+          "disableDataLayers": "Toggle all data layers"
         },
         "info": {
           "title": "Information",

--- a/data/shortcuts.json
+++ b/data/shortcuts.json
@@ -400,6 +400,11 @@
               "shortcuts": ["K"],
               "text": "shortcuts.tools.viewers.kartaview"
             },
+            { 
+              "modifiers": ["⇧"],
+              "shortcuts": ["D"],
+              "text": "shortcuts.tools.viewers.disableDataLayers"
+            },
             {
               "section": "info",
               "text": "shortcuts.tools.info.title"

--- a/modules/ui/sections/data_layers.js
+++ b/modules/ui/sections/data_layers.js
@@ -41,6 +41,31 @@ export function uiSectionDataLayers(context) {
   const settingsCustomData = uiSettingsCustomData(context)
     .on('change', customChanged);
 
+  let previousLayerStates = new Map();
+  function toggleAllLayers() {
+    const allLayerIDs = ['osm', 'notes', 'rapid', 'maproulette', 'keepRight', 'osmose', 'geoScribble', 'custom-data'];
+    const anyLayerEnabled = allLayerIDs.some(layerID => showsLayer(layerID));
+    if (anyLayerEnabled) {
+      // Save current state and disable all layers
+      allLayerIDs.forEach(layerID => {
+        previousLayerStates.set(layerID, showsLayer(layerID));
+        setLayer(layerID, false);
+      });
+    } else {
+      // Restore previous state
+      previousLayerStates.forEach((enabled, layerID) => {
+        setLayer(layerID, enabled);
+      });
+    }
+  }
+
+  // keyboard shortcut for toggling all layers
+  context.keybinding()
+    .on('⇧D', e => {
+      e.preventDefault();
+      toggleAllLayers();
+    });
+
 
 
   /* renderIfVisible

--- a/modules/ui/sections/data_layers.js
+++ b/modules/ui/sections/data_layers.js
@@ -43,7 +43,7 @@ export function uiSectionDataLayers(context) {
 
   let previousLayerStates = new Map();
   function toggleAllLayers() {
-    const allLayerIDs = ['osm', 'notes', 'rapid', 'maproulette', 'keepRight', 'osmose', 'geoScribble', 'custom-data'];
+    const allLayerIDs = ['osm', 'notes', 'rapid', 'maproulette', 'keepRight', 'osmose', 'geoScribble', 'custom-data', 'mapillary', 'streetside', 'kartaview'];
     const anyLayerEnabled = allLayerIDs.some(layerID => showsLayer(layerID));
     if (anyLayerEnabled) {
       // Save current state and disable all layers


### PR DESCRIPTION
### Summary
Introduces a new keyboard shortcut `Shift`+`D` that allows users to quickly hide all data layers, including Rapid and OSM layers, and then toggle them back to their previous states.

### Changes
- Added a function to toggle all data layers on and off.
- Bound the `Shift`+`D` keyboard shortcut to this new function.


https://github.com/user-attachments/assets/cb33d5a5-5b02-4c95-8a85-81eea66f865c


Closes [#1594](https://github.com/facebook/Rapid/issues/1594)