### PR TITLE
Curb validator fixes

### DIFF
--- a/modules/validations/curb_nodes.js
+++ b/modules/validations/curb_nodes.js
@@ -2,6 +2,7 @@ import { geoLatToMeters, geoLonToMeters, geoMetersToLat, geoMetersToLon } from '
 import { actionAddMidpoint, actionChangeTags, actionSplit} from '../actions/index.js';
 import { osmNode } from '../osm/node.js';
 import { ValidationIssue, ValidationFix } from '../core/lib/index.js';
+import { uiIcon } from '../ui/icon.js';
 
 
 export function validationCurbNodes(context) {
@@ -83,12 +84,24 @@ export function validationCurbNodes(context) {
    * @param  {Object} selection - The UI selection to append the reference to
    */
   function showReference(selection) {
-    selection.selectAll('.issue-reference')
+    const referenceEnter = selection.selectAll('.issue-reference')
       .data([0])
       .enter()
       .append('div')
-      .attr('class', 'issue-reference')
+      .attr('class', 'issue-reference');
+    referenceEnter
+      .append('span')
       .text(l10n.t('issues.curb_nodes.reference'));
+    referenceEnter
+      .append('br');
+    const link = referenceEnter
+      .append('a')
+      .attr('href', 'https://wiki.openstreetmap.org/wiki/Key:kerb#:~:text=is%20being%20crossed.-,Values,-%5Bedit%20%7C')
+      .attr('target', '_blank')
+      .attr('title', 'Kerb Tagging Guidelines')
+      .call(uiIcon('#rapid-icon-out-link', 'inline'));
+    link.append('span')
+      .text('More info');
   }
 
 

--- a/modules/validations/curb_nodes.js
+++ b/modules/validations/curb_nodes.js
@@ -150,15 +150,10 @@ export function validationCurbNodes(context) {
     if (hasCurbNode(node, graph)) {
       return; // Exit if curb already exists
     }
-    // Determine if the node is the first or last in the way
-    const isFirstNode = way.nodes[0] === node.id;
-    const isLastNode = way.nodes[way.nodes.length - 1] === node.id;
     // Calculate the position for the new curb node
     const nodeIndex = way.nodes.indexOf(node.id);
-    const adjacentNode = isFirstNode
-      ? graph.entity(way.nodes[nodeIndex + 1])
-      : graph.entity(way.nodes[nodeIndex - 1]);
-    const newNodePosition = calculateNewNodePosition(node, adjacentNode, 1, isLastNode);
+    const adjacentNode = graph.entity(way.nodes[nodeIndex + 1] || way.nodes[nodeIndex - 1]);
+    const newNodePosition = calculateNewNodePosition(node, adjacentNode, 1);
     // Find connected ways and select the appropriate tags
     const connectedWays = graph.parentWays(node);
     let connectedWayTags = null;
@@ -167,10 +162,6 @@ export function validationCurbNodes(context) {
         connectedWayTags = connectedWay.tags;
         break;
       }
-    }
-    if (!connectedWayTags) {
-      console.warn('No connected non-crossing way found');
-      return;
     }
     // Create a new curb node with the specified curb tags
     const newCurbNode = osmNode({ loc: [newNodePosition.lon, newNodePosition.lat], tags: curbTags, visible: true });

--- a/modules/validations/curb_nodes.js
+++ b/modules/validations/curb_nodes.js
@@ -156,7 +156,7 @@ export function validationCurbNodes(context) {
     // Create a new curb node
     const newCurbNode = osmNode({ loc: [newNodePosition.lon, newNodePosition.lat], tags, visible: true });
 
-    // Add the new node to the graph at the midpoint of the specified segment
+    // Add the new node to the graph
     editor.perform(actionAddMidpoint({ loc: newCurbNode.loc, edge: [node.id, adjacentNode.id] }, newCurbNode));
 
     // Perform the split
@@ -164,17 +164,22 @@ export function validationCurbNodes(context) {
     graph = editor.perform(splitAction);
     const newWayIDs = splitAction.getCreatedWayIDs();
 
-    // Change tags to indicate these are sidewalks
-    const sidewalkTags = { highway: 'footway', footway: 'sidewalk' };
-    newWayIDs.forEach(wayId => {
+    // Ensure that the new ways are created correctly
+    if (newWayIDs.length > 0) {
+      // Change tags to indicate these are sidewalks
+      const sidewalkTags = { highway: 'footway', footway: 'sidewalk' };
+      newWayIDs.forEach(wayId => {
         editor.perform(actionChangeTags(wayId, sidewalkTags));
-    });
+      });
 
-    // Commit the changes to the graph
-    editor.commit({
-      annotation: 'Added curb node and updated way tags to sidewalks',
-      selectedIDs: [node.id].concat(newWayIDs)
-    });
+      // Commit the changes to the graph
+      editor.commit({
+        annotation: 'Added curb node and updated way tags to sidewalks',
+        selectedIDs: [node.id].concat(newWayIDs)
+      });
+    } else {
+      console.error('No new ways created after split');
+    }
   }
 
 

--- a/modules/validations/curb_nodes.js
+++ b/modules/validations/curb_nodes.js
@@ -21,7 +21,9 @@ export function validationCurbNodes(context) {
     if (entity.type !== 'way' || entity.isDegenerate()) return [];
     return detectCurbCandidates(entity, graph);
   };
-  const isCrossingWay = (tags) => tags.highway === 'footway' && tags.footway === 'crossing';
+  const isCrossingWay = (tags) => {
+    return (tags.highway === 'footway' && tags.footway === 'crossing') || (tags.highway === 'cycleway' && tags.cycleway === 'crossing');
+  };
 
   const detectCurbCandidates = (way, graph) => {
     let issues = [];
@@ -70,7 +72,7 @@ export function validationCurbNodes(context) {
    * @return {Boolean} True if the way has routable tags, false otherwise
    */
   function hasRoutableTags(way) {
-    const routableTags = ['highway'];
+    const routableTags = ['highway', 'cycleway'];
     return way.isArea() ? false : routableTags.some(tag => way.tags[tag]);
   }
 

--- a/modules/validations/curb_nodes.js
+++ b/modules/validations/curb_nodes.js
@@ -28,8 +28,12 @@ export function validationCurbNodes(context) {
     let issues = [];
     const wayID = way.id;
     if (!hasRoutableTags(way) || !isCrossingWay(way.tags)) return issues;
-    const hasCurbs = hasCurbNodes(way, graph);
-    if (!hasCurbs) {
+    const firstNode = graph.entity(way.nodes[0]);
+    const lastNode = graph.entity(way.nodes[way.nodes.length - 1]);
+    const firstNodeHasCurb = hasCurbNode(firstNode, graph);
+    const lastNodeHasCurb = hasCurbNode(lastNode, graph);
+    // Check if either end is missing a curb
+    if (!firstNodeHasCurb || !lastNodeHasCurb) {
       issues.push(new ValidationIssue(context, {
         type,
         subtype: 'missing_curb_nodes',
@@ -88,17 +92,14 @@ export function validationCurbNodes(context) {
 
 
   /**
-   * hasCurbNodes
-   * Checks if the given way already has curb nodes
-   * @param  {Object} way - The way entity to check
-   * @return {Boolean} True if curb nodes are present, false otherwise
+   * hasCurbNode
+   * Checks if the given node has a curb
+   * @param  {Object} node - The node entity to check
+   * @param  {Object} graph - The graph containing the node data
+   * @return {Boolean} True if the node has a curb, false otherwise
    */
-  function hasCurbNodes(way) {
-    const graph = editor.staging.graph;
-    return way.nodes.some(nodeID => {
-      const node = graph.entity(nodeID);
-      return isCurbNode(node);
-    });
+  function hasCurbNode(node, graph) {
+    return node.tags && node.tags.barrier === 'kerb';
   }
 
 
@@ -115,24 +116,20 @@ export function validationCurbNodes(context) {
       console.error('Way not found:', wayID);
       return;
     }
-
     const firstNode = graph.entity(way.nodes[0]);
     const lastNode = graph.entity(way.nodes[way.nodes.length - 1]);
-
     const firstNodeConnected = isConnectedToRefugeIsland(firstNode, graph);
     const lastNodeConnected = isConnectedToRefugeIsland(lastNode, graph);
-
     // Handle the first node
     if (firstNodeConnected) {
       updateNodeToCurb(firstNode, tags, graph);
-    } else {
+    } else if (!hasCurbNode(firstNode, graph)) {
       curbNodeAdditionForSingleNode(firstNode, way, graph, tags);
     }
-
     // Handle the last node
     if (lastNodeConnected) {
       updateNodeToCurb(lastNode, tags, graph);
-    } else {
+    } else if (!hasCurbNode(lastNode, graph)) {
       curbNodeAdditionForSingleNode(lastNode, way, graph, tags);
     }
   }
@@ -148,6 +145,10 @@ export function validationCurbNodes(context) {
    * @param  {Object} tags - The tags to assign to the new curb node.
    */
   function curbNodeAdditionForSingleNode(node, way, graph, tags) {
+    // Check if the node already has a curb
+    if (hasCurbNode(node, graph)) {
+      return; // Exit if curb already exists
+    }
     // Calculate the position for the new curb node
     const nodeIndex = way.nodes.indexOf(node.id);
     const adjacentNode = graph.entity(way.nodes[nodeIndex + 1] || way.nodes[nodeIndex - 1]);

--- a/test/browser/validations/curb_nodes.js
+++ b/test/browser/validations/curb_nodes.js
@@ -90,10 +90,11 @@ describe('validationCurbNodes', () => {
     verifySingleCurbNodeIssue(issues);
   });
 
-  it('ignores a crossing way with existing curb nodes', () => {
-    const n1 = Rapid.osmNode({ id: 'n-1', loc: [0, -1] });
-    const n2 = Rapid.osmNode({ id: 'n-2', loc: [0,  1] });
-    const n5 = Rapid.osmNode({ id: 'n-5', loc: [0,  0], tags: { barrier: 'kerb' } });
+  it('ignores a crossing way with existing curb nodes at both ends', () => {
+    // Define nodes with curb tags at both ends
+    const n1 = Rapid.osmNode({ id: 'n-1', loc: [0, -1], tags: { barrier: 'kerb' } });
+    const n2 = Rapid.osmNode({ id: 'n-2', loc: [0,  1], tags: { barrier: 'kerb' } });
+    const n5 = Rapid.osmNode({ id: 'n-5', loc: [0,  0] }); // Middle node without curb
     const w1 = Rapid.osmWay({ id: 'w-1', nodes: ['n-1', 'n-5', 'n-2'], tags: { highway: 'footway', footway: 'crossing' } });
 
     const n3 = Rapid.osmNode({ id: 'n-3', loc: [-1, 0] });


### PR DESCRIPTION
Fixes following #1583 

- [x] Validator didn’t flag missing curb on a crossing where the curb on one side is already mapped
[Old](https://rapideditor.org/rapid/pull-request-1583/index.html#map=22.33/34.02915/-118.44355&background=Bing&datasets=fbRoads,msBuildings&disable_features=boundaries&id=w923242107)
[New](https://rapideditor.org/rapid/pull-request-1622/index.html#map=22.33/34.02915/-118.44355&background=Bing&datasets=fbRoads,msBuildings&disable_features=boundaries&id=w923242107)
- [x] Because the crossings are connected to cycleways rather than sidewalks, no issues are flagged within the validator.
[Old](https://rapideditor.org/rapid/pull-request-1583/index.html#map=20.87/53.27614/-6.12207&background=Bing&datasets=fbRoads,msBuildings&disable_features=boundaries)
[New](https://rapideditor.org/rapid/pull-request-1622/index.html#map=20.87/53.27614/-6.12207&background=Bing&datasets=fbRoads,msBuildings&disable_features=boundaries)
- [x] New way that is created always takes sidewalk tag even though its not always a sidewalk 
_You can test this on the above code where the extension way is a cycle way not a sidewalk like the old code use to work._
- [x] Add a link to the [kerb tagging guidelines](https://wiki.openstreetmap.org/wiki/Key:kerb#:~:text=is%20being%20crossed.-,Values,-%5Bedit%20%7C) in the OSM wiki when the user clicks the 'i'?

closes #1619 