### PR TITLE
Remove old IE11/Edge download codepaths

### DIFF
--- a/modules/ui/conflicts.js
+++ b/modules/ui/conflicts.js
@@ -85,15 +85,10 @@ export function uiConflicts(context) {
       .append('a')
       .attr('class', 'download-changes');
 
-    if (detected.download) {   // All except IE11 and Edge
-      linkEnter                // download the data as a file
-        .attr('href', window.URL.createObjectURL(blob))
-        .attr('download', fileName);
-    } else {                   // IE11 and Edge
-      linkEnter                // open data uri in a new tab
-        .attr('target', '_blank')
-        .on('click.download', () => navigator.msSaveBlob(blob, fileName));
-    }
+    // All except IE11 and Edge
+    linkEnter
+      .attr('href', window.URL.createObjectURL(blob)) // download the data as a file
+      .attr('download', fileName);
 
     linkEnter
       .call(uiIcon('#rapid-icon-load', 'inline'))

--- a/modules/ui/sections/changes.js
+++ b/modules/ui/sections/changes.js
@@ -110,16 +110,10 @@ export function uiSectionChanges(context) {
       .append('a')
       .attr('class', 'download-changes');
 
-    if (detected.download) {    // All except IE11 and Edge
-      linkEnter                 // download the data as a file
-        .attr('href', window.URL.createObjectURL(blob))
-        .attr('download', fileName);
-
-    } else {                    // IE11 and Edge
-      linkEnter                 // open data uri in a new tab
-        .attr('target', '_blank')
-        .on('click.download', () => navigator.msSaveBlob(blob, fileName));
-    }
+    // All except IE11 and Edge
+    linkEnter
+      .attr('href', window.URL.createObjectURL(blob)) // download the data as a file
+      .attr('download', fileName);
 
     linkEnter
       .call(uiIcon('#rapid-icon-load', 'inline'))


### PR DESCRIPTION
Other IE11/Edge codepaths were removed a few years ago but these ones remained untouched (which caused ceba2f3264d3ae23d093c3a3859c7f6e7298313d to break file download because the code used the now-removed support conditionals that caused it to use a fallback path with MS JavaScript extensions)

Fixes #1655