### PR TITLE
Add default "sidewalk" tags when connectedWayTags is null

### DIFF
--- a/modules/validations/curb_nodes.js
+++ b/modules/validations/curb_nodes.js
@@ -203,6 +203,10 @@ export function validationCurbNodes(context) {
         break;
       }
     }
+    // Check if connectedWayTags is null and set default to "sidewalk"
+    if (connectedWayTags === null) {
+      connectedWayTags = { highway: 'footway' };
+    }
     // Create a new curb node with the specified curb tags
     const newCurbNode = osmNode({ loc: [newNodePosition.lon, newNodePosition.lat], tags: curbTags, visible: true });
     // Add the new node to the graph


### PR DESCRIPTION
### Summary
This PR addresses issue #1654 by adding a check in the `insertCurbNode` function to handle cases where `connectedWayTags` is null. If no connected way tags are found, the function now defaults to using "sidewalk" tags.

### Changes
- Added a check for `connectedWayTags` being null.
- Default to `{ highway: "sidewalk" }` tags when no connected way tags are available.

Closes #1654