### PR TITLE
maproulette_details: Remove nested p-tags

### DIFF
--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -142,7 +142,6 @@ export function uiMapRouletteDetails(context) {
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.detail_title'));
         selection
-          .append('div')
           .html(description)  // parsed markdown
           .selectAll('a')
           .attr('rel', 'noopener')
@@ -154,7 +153,6 @@ export function uiMapRouletteDetails(context) {
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.instruction_title'));
         selection
-          .append('div')
           .html(instruction)  // parsed markdown
           .selectAll('a')
           .attr('rel', 'noopener')

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -142,7 +142,7 @@ export function uiMapRouletteDetails(context) {
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.detail_title'));
         selection
-          .append('p')
+          .append('div')
           .html(description)  // parsed markdown
           .selectAll('a')
           .attr('rel', 'noopener')
@@ -154,7 +154,7 @@ export function uiMapRouletteDetails(context) {
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.instruction_title'));
         selection
-          .append('p')
+          .append('div')
           .html(instruction)  // parsed markdown
           .selectAll('a')
           .attr('rel', 'noopener')


### PR DESCRIPTION
The `append('p')` followed by `html(markdown)` resulted in nested p-tags which are not ideal for the browser to handle.

~~I kept the wrapper in place but changed it to a `div` instead, just in case.~~ — Update: Actually, the `div` breaks the margins/paddings so having it without any wrapper looks best.

Before

> <img width="295" alt="image" src="https://github.com/user-attachments/assets/0cb1e92b-3656-403f-beb4-50d664fa7bc6" />

After (Simulated in Inspector)

> <img width="395" alt="image" src="https://github.com/user-attachments/assets/d5448122-e565-43dc-9349-48c49013080c" />


---

Maybe related to https://github.com/facebook/Rapid/issues/1686