### PR TITLE
Maproulette fixes and improvements

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2812,6 +2812,17 @@ img.tag-reference-wiki-image {
   padding-top: 20px;
 }
 
+.qa-details-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 20px;
+  padding: 0 10px;
+}
+/* Specify margin when one is followed by the other */
+.qa-details-header+.qa-details-container {
+  margin-top: 8px;
+}
 .qa-details-container {
   background: #ececec;
   padding: 10px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2737,6 +2737,7 @@ img.tag-reference-wiki-image {
   font-size: 14px;
   font-weight: bold;
   border-radius: 0 5px 5px 0;
+  line-height: 19px;
 }
 .ideditor[dir='rtl'] .data-header-label,
 .ideditor[dir='rtl'] .note-header-label,

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2821,6 +2821,22 @@ img.tag-reference-wiki-image {
   display: flex;
   flex-direction: column;
 }
+.qa-details-container h1,
+.qa-details-container h2,
+.qa-details-container h3,
+.qa-details-container h3 {
+  font-size: 18px;
+}
+.qa-details-container ul,
+.qa-details-container ol {
+  margin-left: 20px;
+}
+.qa-details-container li {
+  list-style: auto;
+}
+.qa-details-container ul li {
+  list-style: disc;
+}
 .qa-details-description-text::first-letter {
   text-transform: capitalize;
 }

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -799,6 +799,7 @@ en:
           one: MapRoulette Task
           other: MapRoulette Tasks
         loading_task_details: Loading Task Details...
+        error_loading_task_details: Error while loading the task details. Try waiting and selecting it again.
         detail_title: Details
         id_title: Challenge Id / Task Id
         id_placeholder: Challenge IDs

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -1012,6 +1012,7 @@
             "other": "MapRoulette Tasks"
           },
           "loading_task_details": "Loading Task Details...",
+          "error_loading_task_details": "Error while loading the task details. Try waiting and selecting it again.",
           "detail_title": "Details",
           "id_title": "Challenge Id / Task Id",
           "id_placeholder": "Challenge IDs",

--- a/modules/services/MapRouletteService.js
+++ b/modules/services/MapRouletteService.js
@@ -315,6 +315,8 @@ export class MapRouletteService extends AbstractSystem {
 
   /**
    * loadTaskDetailAsync
+   * This loads the challenge data (not the task) and add the task GeoJSON features to it
+   * https://maproulette.org/docs/swagger-ui/index.html#/Challenge/read
    * @param   task
    * @return  Promise
    */
@@ -325,6 +327,30 @@ export class MapRouletteService extends AbstractSystem {
     const handleResponse = (data) => {
       task.instruction = marked.parse(data.instruction) || '';
       task.description = marked.parse(data.description) || '';
+      return task;
+    };
+
+    return fetch(url)
+      .then(utilFetchResponse)
+      .then(handleResponse)
+      .then(this.loadTaskTaskDetailAsync);
+  }
+
+
+  /**
+   * loadTaskDetailAsync
+   * This loads the task data and adds the geojson properties that are embedded into the task as `taskFeatures`.
+   * Those properties are used to replace the Mustache tags in the challenge.instruction/.description.
+   * https://maproulette.org/docs/swagger-ui/index.html#/Task/read
+   * @param   task
+   * @return  Promise
+   */
+  loadTaskTaskDetailAsync(task) {
+    if (task.taskInstructions !== undefined) return Promise.resolve(task);  // already done
+
+    const url = `${MAPROULETTE_API}/task/${task.id}`;
+    const handleResponse = (data) => {
+      task.taskFeatures = data.geometries.features;
       return task;
     };
 

--- a/modules/services/MapRouletteService.js
+++ b/modules/services/MapRouletteService.js
@@ -4,7 +4,6 @@ import RBush from 'rbush';
 import { AbstractSystem } from '../core/AbstractSystem';
 import { QAItem } from '../osm/qa_item.js';
 import { utilFetchResponse } from '../util';
-import { marked } from 'marked';
 
 const TILEZOOM = 14;
 const MAPROULETTE_API = 'https://maproulette.org/api/v2';
@@ -325,8 +324,8 @@ export class MapRouletteService extends AbstractSystem {
 
     const url = `${MAPROULETTE_API}/challenge/${task.parentId}`;
     const handleResponse = (data) => {
-      task.instruction = marked.parse(data.instruction) || '';
-      task.description = marked.parse(data.description) || '';
+      task.instruction = data.instruction || '';
+      task.description = data.description || '';
       return task;
     };
 

--- a/modules/ui/detection_details.js
+++ b/modules/ui/detection_details.js
@@ -16,7 +16,7 @@ export function uiDetectionDetails(context) {
 
 
   function render(selection) {
-    const $details = selection.selectAll('.error-details')
+    const $details = selection.selectAll('.sidebar-details')
       .data(_detection ? [_detection] : [], d => d.key);
 
     $details.exit()
@@ -24,7 +24,7 @@ export function uiDetectionDetails(context) {
 
     const $$details = $details.enter()
       .append('div')
-      .attr('class', 'error-details qa-details-container');
+      .attr('class', 'sidebar-details qa-details-container');
 
     // description
     const $$description = $$details

--- a/modules/ui/keepRight_details.js
+++ b/modules/ui/keepRight_details.js
@@ -30,7 +30,7 @@ export function uiKeepRightDetails(context) {
 
 
   function render(selection) {
-    const details = selection.selectAll('.error-details')
+    const details = selection.selectAll('.sidebar-details')
       .data(_qaItem ? [_qaItem] : [], d => d.key);
 
     details.exit()
@@ -38,7 +38,7 @@ export function uiKeepRightDetails(context) {
 
     const detailsEnter = details.enter()
       .append('div')
-      .attr('class', 'error-details qa-details-container');
+      .attr('class', 'sidebar-details qa-details-container');
 
     // description
     const descriptionEnter = detailsEnter

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -1,6 +1,7 @@
 import { select as d3_select } from 'd3-selection';
 
 import { utilHighlightEntities } from '../util/index.js';
+import { marked } from 'marked';
 
 export function uiMapRouletteDetails(context) {
   const l10n = context.systems.l10n;
@@ -143,15 +144,16 @@ export function uiMapRouletteDetails(context) {
           .attr('target', '_blank');
       }
 
-      const description = generateDynamicContent(replaceMustacheTags(task.description, task));
-      const instruction = generateDynamicContent(replaceMustacheTags(task.instruction, task));
+      const descriptionHtml = generateDynamicContent(marked.parse(replaceMustacheTags(task.description, task), { async: false }));
+      const instructionHtml = generateDynamicContent(marked.parse(replaceMustacheTags(task.instruction, task), { async: false }));
+
       if (task.description) {
         selection
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.detail_title'));
         selection
           .append('p')
-          .html(description)  // parsed markdown
+          .html(descriptionHtml)  // parsed markdown
           .selectAll('a')
           .attr('rel', 'noopener')
           .attr('target', '_blank');
@@ -163,7 +165,7 @@ export function uiMapRouletteDetails(context) {
           .text(l10n.t('map_data.layers.maproulette.instruction_title'));
         selection
           .append('p')
-          .html(instruction)  // parsed markdown
+          .html(instructionHtml)  // parsed markdown
           .selectAll('a')
           .attr('rel', 'noopener')
           .attr('target', '_blank');

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -147,7 +147,10 @@ export function uiMapRouletteDetails(context) {
       const descriptionHtml = generateDynamicContent(marked.parse(replaceMustacheTags(task.description, task), { async: false }));
       const instructionHtml = generateDynamicContent(marked.parse(replaceMustacheTags(task.instruction, task), { async: false }));
 
-      if (task.description) {
+      // We show the challenge description when user select an unkown challenge.
+      // But we hide it if a specific (assumed to be know) challenge is selected.
+      const explicitChallengeIdGiven = Boolean(maproulette.challengeIDs);
+      if (!explicitChallengeIdGiven && task.description) {
         selection
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.detail_title'));

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -50,7 +50,7 @@ export function uiMapRouletteDetails(context) {
 
 
   /**
-   * This function searches for mustache tags defined by double curly braces (e.g., {{propertyName}}) and replaces them
+   * This function searches for mustache tags defined by double curly braces (e.g., `{{propertyName}}`) and replaces them
    * with actual values from the task's properties or generates clickable links if the property is an OSM identifier.
    * https://learn.maproulette.org/en-us/documentation/mustache-tag-replacement/#content
    * @param {string} text The text containing mustache tags to be replaced.
@@ -68,8 +68,16 @@ export function uiMapRouletteDetails(context) {
         return `<a href="#" class="highlight-link" data-osm-id="${osmId}">${osmId}</a>`;
       }
       // For other properties, return their values from the task if they exist
-      if (task.properties && task.properties.hasOwnProperty(propertyName)) {
-        return task.properties[propertyName];
+      // Tasks have a featureCollection. Usually there is only one feature, but we still have to handle multiple.
+      // In case properties are duplicated between features, we take the last value. I don't expect this to happen or be an issue.
+      const allProperties = new Map();
+      task.taskFeatures.map(f => f.properties).forEach(properties => {
+        Object.keys(properties).forEach(key => {
+          allProperties.set(key, properties[key]);
+        });
+      });
+      if (allProperties.has(propertyName)) {
+        return allProperties.get(propertyName);
       }
       // Return an empty string if the property does not exist in the task
       return '';

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -230,6 +230,7 @@ export function uiMapRouletteDetails(context) {
           highlightFeature(osmId);
         });
     }).catch(e => {
+      console.error('error_loading_task_details:', e);
       const selection = details.selectAll('.qa-details-subsection');
       selection.html(''); // replace contents
       const error = selection

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -116,13 +116,18 @@ export function uiMapRouletteDetails(context) {
     let details = selection.selectAll('.sidebar-details')
       .data(_qaItem ? [_qaItem] : [], d => d.key);
     details.exit().remove();
-    const detailsEnter = details.enter()
-      .append('div')
-      .attr('class', 'sidebar-details qa-details-container');
 
-    detailsEnter.append('div')
-      .attr('class', 'qa-details-subsection')
-      .text(l10n.t('map_data.layers.maproulette.loading_task_details'));
+    const detailsEnter = details.enter()
+      .append('section')
+      .attr('class', 'sidebar-details');
+    const qaDetails = detailsEnter
+      .append('div')
+      .attr('class', 'qa-details-subsection');
+
+    const loading = qaDetails
+      .append('div')
+      .attr('class', 'qa-details-container');
+    loading.text(l10n.t('map_data.layers.maproulette.loading_task_details'));
 
     details = details.merge(detailsEnter);
 
@@ -130,13 +135,17 @@ export function uiMapRouletteDetails(context) {
       if (!task) return;
       if (_qaItem.id !== task.id) return;
       const selection = details.selectAll('.qa-details-subsection');
-      selection.html('');   // replace contents
+      selection.html(''); // replace contents
+
       // Display Challenge ID and Task ID
       if (task.id) {
-        selection
+        const titleSection = selection
+          .append('header')
+          .attr('class', 'qa-details-header');
+        titleSection
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.id_title'));
-        selection
+        titleSection
           .append('p')
           .text(`${task.parentId} / ${task.id}`)
           .selectAll('a')
@@ -151,24 +160,38 @@ export function uiMapRouletteDetails(context) {
       // But we hide it if a specific (assumed to be know) challenge is selected.
       const explicitChallengeIdGiven = Boolean(maproulette.challengeIDs);
       if (!explicitChallengeIdGiven && task.description) {
-        selection
+        const descSection = selection
+          .append('article');
+        const descHeader = descSection
+          .append('header')
+          .attr('class', 'qa-details-header');
+        descHeader
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.detail_title'));
-        selection
-          .append('p')
-          .html(descriptionHtml)  // parsed markdown
+        const descContent = descSection
+          .append('section')
+          .attr('class', 'qa-details-container');
+        descContent
+          .html(descriptionHtml)
           .selectAll('a')
           .attr('rel', 'noopener')
           .attr('target', '_blank');
       }
 
       if (task.instruction && task.instruction !== task.description) {
-        selection
+        const instructionSection = selection
+          .append('article');
+        const descHeader = instructionSection
+          .append('header')
+          .attr('class', 'qa-details-header');
+        descHeader
           .append('h4')
           .text(l10n.t('map_data.layers.maproulette.instruction_title'));
-        selection
-          .append('p')
-          .html(instructionHtml)  // parsed markdown
+        const instructionContent = instructionSection
+          .append('article')
+          .attr('class', 'qa-details-container');
+        instructionContent
+          .html(instructionHtml)
           .selectAll('a')
           .attr('rel', 'noopener')
           .attr('target', '_blank');
@@ -207,7 +230,12 @@ export function uiMapRouletteDetails(context) {
           highlightFeature(osmId);
         });
     }).catch(e => {
-        details.selectAll('.qa-details-subsection').text(l10n.t('map_data.layers.maproulette.error_loading_task_details'));
+      const selection = details.selectAll('.qa-details-subsection');
+      selection.html(''); // replace contents
+      const error = selection
+        .append('div')
+        .attr('class', 'qa-details-container');
+      error.text(l10n.t('map_data.layers.maproulette.error_loading_task_details'));
     });
   }
 

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -171,19 +171,35 @@ export function uiMapRouletteDetails(context) {
           .attr('target', '_blank');
       }
 
+      /**
+       * Transform the `${type}/${number}` pattern to the `${w|n|r}${number}` pattern
+       * Correct format: `w${number}`, `n${number}`, `r${number}`
+       * Format that this helper transforms: `way/${number}`, `node/${number}`, `relation/${number}`
+       */
+      const transformId = (id) => {
+        return id.replace(/^(way|node|relation)\//, (match) => {
+          switch (match) {
+            case 'way/': return 'w';
+            case 'node/': return 'n';
+            case 'relation/': return 'r';
+            default: return match;
+          }
+        });
+      };
+
       // Attach hover and click event listeners
       selection.selectAll('.highlight-link')
-        .on('mouseover', function() {
-          const osmId = d3_select(this).attr('data-osm-id');
+        .on('mouseover', function () {
+          const osmId = transformId(d3_select(this).attr('data-osm-id'));
           utilHighlightEntities([osmId], true, context);
         })
         .on('mouseout', function() {
-          const osmId = d3_select(this).attr('data-osm-id');
+          const osmId = transformId(d3_select(this).attr('data-osm-id'));
           utilHighlightEntities([osmId], false, context);
         })
         .on('click', function(d3_event) {
           d3_event.preventDefault();
-          const osmId = d3_select(this).attr('data-osm-id');
+          const osmId = transformId(d3_select(this).attr('data-osm-id'));
           utilHighlightEntities([osmId], false, context);
           highlightFeature(osmId);
         });

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -104,12 +104,12 @@ export function uiMapRouletteDetails(context) {
    * @param {d3.selection} selection The D3 selection where the challenge details should be rendered.
    */
   function render(selection) {
-    let details = selection.selectAll('.error-details')
+    let details = selection.selectAll('.sidebar-details')
       .data(_qaItem ? [_qaItem] : [], d => d.key);
     details.exit().remove();
     const detailsEnter = details.enter()
       .append('div')
-      .attr('class', 'error-details qa-details-container');
+      .attr('class', 'sidebar-details qa-details-container');
 
     detailsEnter.append('div')
       .attr('class', 'qa-details-subsection')

--- a/modules/ui/maproulette_details.js
+++ b/modules/ui/maproulette_details.js
@@ -79,8 +79,8 @@ export function uiMapRouletteDetails(context) {
       if (allProperties.has(propertyName)) {
         return allProperties.get(propertyName);
       }
-      // Return an empty string if the property does not exist in the task
-      return '';
+      // Return an non-replaced Mustache tag if the property does not exist in the task to signal that there is something that we could not replace
+      return `{{${propertyName}}}`;
     });
   }
 

--- a/modules/ui/osmose_details.js
+++ b/modules/ui/osmose_details.js
@@ -26,7 +26,7 @@ export function uiOsmoseDetails(context) {
 
 
   function render(selection) {
-    const details = selection.selectAll('.error-details')
+    const details = selection.selectAll('.sidebar-details')
       .data(_qaItem ? [_qaItem] : [], d => d.key);
 
     details.exit()
@@ -34,7 +34,7 @@ export function uiOsmoseDetails(context) {
 
     const detailsEnter = details.enter()
       .append('div')
-      .attr('class', 'error-details qa-details-container');
+      .attr('class', 'sidebar-details qa-details-container');
 
 
     // Description


### PR DESCRIPTION
This PR does a couple of things. They are separated into commits. Let me know which I should extract into separate PRs (if any).

The commits describe what is going on and why; I list them below with some added screenshots.

This what the new UI looks like:

> <img width="638" alt="sidebar" src="https://github.com/user-attachments/assets/3f144d1d-3706-4cf7-88b3-c4a5d6b75915" />


**Test-Location:** https://rapideditor.org/edit#map=19.38/52.48353/13.44032&maproulette=49357&background=Berlin-2024&datasets=fbRoads,msBuildings&disable_features=boundaries


---


### MapRoulette: Fix Mustache property replacement by loading task geometries

Even though the method name is called "task" what it actually loaded was the MapRoulette "challenge". Which means we did not have the actual task properties to replace the Mustache tags.

Now we also load the task but only add the features which hold the properties. In MR one task has a FeatureCollection attached which holds geometries that are displayed in the UI and properties. Usually this is only one feature (there are special cases). We now flatten the properties of all features and use this list to replace the Mustache tags.

---

### MapRoulette: Only remove Mustache tag if replaced

This way it is clear that something was there but was not replaced. I think this is easier to understand than showing nothing.

---


### MapRoulette: Fix the markdown parsing

Before, the markdown parsing was done on the initial data. However, this data can include Mustache tags which are replaced later which also can hold Markdown.

Now we parse the Markdown after replacing all Mustache tags.

---


### MapRoulette: Fix osmIdentifier links which interact with the map

The Mustache replacement also handels a special case of `osmIdentifier` which create a special link that hovers or selects the element in the map.

This change fixes this feature for all cases when the OSM identifier follows the pattern `way/${number}`, `node/${number}`, `relation/${number}`

| hover | selected |
|--------|--------|
| <img width="741" alt="link-hover" src="https://github.com/user-attachments/assets/b741fcd7-464b-4fed-8d79-adf27e345d02" /> | <img width="737" alt="link-selected" src="https://github.com/user-attachments/assets/bbca9cf3-f026-4f0a-8cbc-4e19cdf0fe31" /> |

---


### MapRoulette: Hide Challenge Desc when an explicit challenge is selected

The challenge description is a high level description on the challenge which is great when one select a MR node without knowing the challenge.

However, when a explicit challenge ID is selected, we can assume the challenge is known beforehand so this hides it to reduce clutter on the page.

| no challenge specified | with challenge specified |
|--------|--------|
| <img width="1259" alt="id-none" src="https://github.com/user-attachments/assets/84a200ae-2620-4b5d-b135-feaae3e2ef2f" /> | <img width="1251" alt="id-given" src="https://github.com/user-attachments/assets/ceda665b-ff59-4574-a2cf-d0e7e876a7a9" /> | 

---


### MapRoulette: Apply default styles to Markdown

The markdown that is provided by the challenge authors can add headlines and lists to the sidebar. This adds some basic styling for this case.

---


### MapRoulette: Improve sidebar design

The sidebar showed all information in one gray box, which made it hard to distinguish the challenge description and task instruction; especially when the challenge authors used headlines in their text as well.

This changes the UI to show description and instruction in separate boxes and updates the loading and error messages to work with this updated design.

<img width="613" alt="loading" src="https://github.com/user-attachments/assets/bcdc8add-f23c-4ac5-929b-a71a863d8ec8" />
<img width="636" alt="error" src="https://github.com/user-attachments/assets/4f7a8483-8758-42a2-bf08-ddbcd753aab8" />


---

Other small changes
- MapRoulette: Add error logging — This makes it easier to debug the error cases when the MR API returns an error.
- MapRoulette: Add missing translation for error message
- MapRoulette: Reduce line height for Sidebar title
- Rename css class for QA tools — We use the same class for the MapRoulette Sidepanel and the term error was confusing.





---

Closes https://github.com/facebook/Rapid/issues/1686

