### PR TITLE
Fix SecurityError in cross-origin context

### DIFF
--- a/modules/util/detect.js
+++ b/modules/util/detect.js
@@ -87,13 +87,22 @@ export function utilDetect(refresh) {
   _cached.locales = navigator.languages.slice();  // shallow copy
 
   /* Host */
-  const loc = window.top.location;
-  let origin = loc.origin;
+  let loc, origin, pathname;
+  try {
+    loc = window.top.location;
+    origin = loc.origin;
+    pathname = loc.pathname;
+  } catch {
+    loc = window.location;
+    origin = loc.origin;
+    pathname = loc.pathname;
+  }
+
   if (!origin) {  // for unpatched IE11
     origin = loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port: '');
   }
 
-  _cached.host = origin + loc.pathname;
+  _cached.host = origin + pathname;
 
   _cached.prefersColorScheme = window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   _cached.prefersContrast = window.matchMedia?.('(prefers-contrast: more)').matches ? 'more'


### PR DESCRIPTION
Add fallback to window.location when window.top.location properties are inaccessible due to cross-origin restrictions.

E.g.

Uncaught SecurityError: Failed to read a named property 'origin' from 'Location': Blocked a frame with origin "..." from accessing a cross-origin frame.