### PR TITLE
Change validation message rendering from html to text.

### DIFF
--- a/modules/ui/commit_warnings.js
+++ b/modules/ui/commit_warnings.js
@@ -82,7 +82,7 @@ export function uiCommitWarnings(context) {
         .merge(items);
 
       items.selectAll('.issue-message')
-        .html(d => d.message(context));
+        .text(d => d.message(context));
     }
   }
 

--- a/modules/ui/sections/entity_issues.js
+++ b/modules/ui/sections/entity_issues.js
@@ -159,7 +159,7 @@ export function uiSectionEntityIssues(context) {
       .classed('active', d => d.id === _activeIssueID);
 
     containers.selectAll('.issue-message')
-      .html(d => d.message(context));
+      .text(d => d.message(context));
 
     // fixes
     let fixLists = containers.selectAll('.issue-fix-list');

--- a/modules/ui/sections/validation_issues.js
+++ b/modules/ui/sections/validation_issues.js
@@ -129,7 +129,7 @@ export function uiSectionValidationIssues(context, severity) {
       .order();
 
     items.selectAll('.issue-message')
-      .html(d => d.message(context));
+      .text(d => d.message(context));
 
     items.selectAll('.issue-autofix')
       .classed('hide', d => !(showAutoFix && d.autoArgs));


### PR DESCRIPTION
We shouldn't render issue labels with html, as they can contain user-input text (such as the name of an entity). 