### PR TITLE
TomTom roads from Overture transportation tiles

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1168,6 +1168,9 @@ en:
       ml_buildings:
         label: Microsoft ML + Google Open Buildings
         description: "ML-derived building footprints from Microsoft and Google Open Buildings, conflated by the Overture Maps Foundation."
+      tomtom_roads:
+        label: TomTom Roads
+        description: "Road network data sourced from TomTom, available through the Overture Maps Foundation."
     omdFootways:
       label: Open Data Footways
       description: Open footways data collected from various local government entities.

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -1455,6 +1455,10 @@
         "ml_buildings": {
           "label": "Microsoft ML + Google Open Buildings",
           "description": "ML-derived building footprints from Microsoft and Google Open Buildings, conflated by the Overture Maps Foundation."
+        },
+        "tomtom_roads": {
+          "label": "TomTom Roads",
+          "description": "Road network data sourced from TomTom, available through the Overture Maps Foundation."
         }
       },
       "omdFootways": {

--- a/modules/actions/rapid_accept_feature.js
+++ b/modules/actions/rapid_accept_feature.js
@@ -1,6 +1,10 @@
-import { vecInterp } from '@rapid-sdk/math';
+import { Extent, geoMetersToLat, geoMetersToLon, geoSphericalDistance, vecInterp, vecProject } from '@rapid-sdk/math';
 
 import { osmNode, osmRelation, osmWay } from '../osm/index.js';
+import { osmRoutableHighwayTagValues } from '../osm/tags.js';
+
+const AUTO_CONNECT_METERS = 5;    // max distance to snap endpoint to nearby highway
+const NODE_MERGE_METERS = 1;   // reuse existing node if within this distance
 
 
 function findConnectionPoint(graph, newNode, targetWay, nodeA, nodeB) {
@@ -72,7 +76,7 @@ function removeMetadata(entity) {
 }
 
 
-export function actionRapidAcceptFeature(entityID, extGraph) {
+export function actionRapidAcceptFeature(entityID, extGraph, tree) {
     return function(graph) {
         var seenRelations = {};    // keep track of seen relations to avoid infinite recursion
         var extEntity = extGraph.entity(entityID);
@@ -86,6 +90,120 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
         }
 
         return graph;
+
+
+        function canConnect(way1, way2) {
+            if (way1.id === way2.id) return false;
+
+            var b1 = way1.tags.bridge && way1.tags.bridge !== 'no';
+            var b2 = way2.tags.bridge && way2.tags.bridge !== 'no';
+            if ((b1 || b2) && !(b1 && b2)) return false;
+
+            var t1 = way1.tags.tunnel && way1.tags.tunnel !== 'no';
+            var t2 = way2.tags.tunnel && way2.tags.tunnel !== 'no';
+            if ((t1 || t2) && !(t1 && t2)) return false;
+
+            if ((way1.tags.layer || '0') !== (way2.tags.layer || '0')) return false;
+            if ((way1.tags.level || '0') !== (way2.tags.level || '0')) return false;
+
+            return true;
+        }
+
+
+        function autoConnectEndpoint(node, acceptedWay) {
+            if (!tree) return null;
+
+            var loc = node.loc;
+            var lonRange = geoMetersToLon(AUTO_CONNECT_METERS, loc[1]);
+            var latRange = geoMetersToLat(AUTO_CONNECT_METERS);
+            var queryExtent = new Extent(
+                [loc[0] - lonRange, loc[1] - latRange],
+                [loc[0] + lonRange, loc[1] + latRange]
+            );
+
+            var segmentInfos = tree.waySegments(queryExtent, graph);
+            var bestDist = Infinity;
+            var bestResult = null;
+
+            for (var i = 0; i < segmentInfos.length; i++) {
+                var segInfo = segmentInfos[i];
+                var targetWay = graph.hasEntity(segInfo.wayId);
+                if (!targetWay) continue;
+                if (!targetWay.tags.highway || !osmRoutableHighwayTagValues[targetWay.tags.highway]) continue;
+                if (!canConnect(acceptedWay, targetWay)) continue;
+
+                var nA = graph.hasEntity(segInfo.nodes[0]);
+                var nB = graph.hasEntity(segInfo.nodes[1]);
+                if (!nA || !nB) continue;
+
+                // Check for node merge (dupe-like) — prefer merging to existing endpoints
+                var distA = geoSphericalDistance(loc, nA.loc);
+                if (distA < NODE_MERGE_METERS && distA < bestDist) {
+                    bestDist = distA;
+                    bestResult = { mergeNodeId: nA.id, targetWayId: segInfo.wayId };
+                }
+                var distB = geoSphericalDistance(loc, nB.loc);
+                if (distB < NODE_MERGE_METERS && distB < bestDist) {
+                    bestDist = distB;
+                    bestResult = { mergeNodeId: nB.id, targetWayId: segInfo.wayId };
+                }
+
+                // Project onto segment
+                var projected = vecProject(loc, [nA.loc, nB.loc]);
+                if (projected) {
+                    var projDist = geoSphericalDistance(loc, projected.target);
+                    if (projDist < AUTO_CONNECT_METERS && projDist < bestDist) {
+                        // If projection lands near an existing segment endpoint, merge instead of snap
+                        var distToA = geoSphericalDistance(projected.target, nA.loc);
+                        var distToB = geoSphericalDistance(projected.target, nB.loc);
+                        if (distToA < NODE_MERGE_METERS) {
+                            bestDist = projDist;
+                            bestResult = { mergeNodeId: nA.id, targetWayId: segInfo.wayId };
+                        } else if (distToB < NODE_MERGE_METERS) {
+                            bestDist = projDist;
+                            bestResult = { mergeNodeId: nB.id, targetWayId: segInfo.wayId };
+                        } else {
+                            bestDist = projDist;
+                            bestResult = { snapLoc: projected.target, edge: [nA.id, nB.id], targetWayId: segInfo.wayId };
+                        }
+                    }
+                }
+            }
+
+            if (!bestResult) return null;
+
+            // Get the connected highway tag before modifying the graph
+            var connectedHighwayTag = graph.entity(bestResult.targetWayId).tags.highway;
+
+            if (bestResult.mergeNodeId) {
+                // Replace endpoint references in accepted way with existing node
+                var updatedNodes = acceptedWay.nodes.map(function(nid) {
+                    return nid === node.id ? bestResult.mergeNodeId : nid;
+                });
+                graph = graph.replace(acceptedWay.update({ nodes: updatedNodes }));
+                // Remove the orphaned original node
+                graph = graph.remove(node);
+            } else {
+                // Snap node to projected point on segment, splice into target way
+                node = node.move(bestResult.snapLoc);
+                graph = graph.replace(node);
+
+                var targetWay = graph.entity(bestResult.targetWayId);
+                var nidList = targetWay.nodes;
+                var nAid = bestResult.edge[0];
+                var nBid = bestResult.edge[1];
+
+                // Find the exact edge in the target way's node list
+                for (var k = 0; k < nidList.length - 1; k++) {
+                    if (nidList[k] === nAid && nidList[k + 1] === nBid) {
+                        graph = graph.replace(targetWay.addNode(node.id, k + 1));
+                        break;
+                    }
+                }
+            }
+
+            return connectedHighwayTag;
+        }
 
 
         // These functions each accept the external entities, returning the replacement
@@ -109,13 +227,21 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
             way.tags = Object.assign({}, way.tags);
             removeMetadata(way);
 
-            var nodes = way.nodes.map(function(nodeId) {
+            var firstNodeHadConn = false;
+            var lastNodeHadConn = false;
+
+            var nodes = way.nodes.map(function(nodeId, index) {
                 // copy node before modifying
                 var node = osmNode(extGraph.entity(nodeId));
                 node.tags = Object.assign({}, node.tags);
 
                 var conn = node.tags.conn && node.tags.conn.split(',');
                 var dupeId = node.tags.dupe;
+
+                // Track endpoints with existing connection metadata
+                if (index === 0 && (conn || dupeId)) firstNodeHadConn = true;
+                if (index === extWay.nodes.length - 1 && (conn || dupeId)) lastNodeHadConn = true;
+
                 removeMetadata(node);
 
                 if (dupeId && graph.hasEntity(dupeId) && !locationChanged(graph.entity(dupeId).loc, node.loc)) {
@@ -145,7 +271,28 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
 
             way = way.update({ nodes: nodes });
             graph = graph.replace(way);
-            return way;
+
+            // Auto-connect endpoints that had no conn/dupe tags
+            if (tree && !way.isClosed()) {
+                var connectedHighwayTag = null;
+                if (!firstNodeHadConn) {
+                    var tag = autoConnectEndpoint(graph.entity(way.nodes[0]), graph.entity(way.id));
+                    if (tag) connectedHighwayTag = tag;
+                    way = graph.entity(way.id);  // re-fetch after potential modification
+                }
+                if (!lastNodeHadConn) {
+                    var tag = autoConnectEndpoint(graph.entity(way.nodes[way.nodes.length - 1]), graph.entity(way.id));
+                    if (tag) connectedHighwayTag = tag;
+                    way = graph.entity(way.id);  // re-fetch after potential modification
+                }
+
+                // Inherit highway tag from connected way if accepted way has generic 'road' classification
+                if (connectedHighwayTag && way.tags.highway === 'road') {
+                    graph = graph.replace(way.update({ tags: Object.assign({}, way.tags, { highway: connectedHighwayTag }) }));
+                }
+            }
+
+            return graph.entity(way.id);
         }
 
 

--- a/modules/actions/rapid_accept_feature.js
+++ b/modules/actions/rapid_accept_feature.js
@@ -125,9 +125,10 @@ export function actionRapidAcceptFeature(entityID, extGraph, tree) {
             var bestDist = Infinity;
             var bestResult = null;
 
+            var targetWay;
             for (var i = 0; i < segmentInfos.length; i++) {
                 var segInfo = segmentInfos[i];
-                var targetWay = graph.hasEntity(segInfo.wayId);
+                targetWay = graph.hasEntity(segInfo.wayId);
                 if (!targetWay) continue;
                 if (!targetWay.tags.highway || !osmRoutableHighwayTagValues[targetWay.tags.highway]) continue;
                 if (!canConnect(acceptedWay, targetWay)) continue;
@@ -188,7 +189,7 @@ export function actionRapidAcceptFeature(entityID, extGraph, tree) {
                 node = node.move(bestResult.snapLoc);
                 graph = graph.replace(node);
 
-                var targetWay = graph.entity(bestResult.targetWayId);
+                targetWay = graph.entity(bestResult.targetWayId);
                 var nidList = targetWay.nodes;
                 var nAid = bestResult.edge[0];
                 var nBid = bestResult.edge[1];
@@ -275,13 +276,14 @@ export function actionRapidAcceptFeature(entityID, extGraph, tree) {
             // Auto-connect endpoints that had no conn/dupe tags
             if (tree && !way.isClosed()) {
                 var connectedHighwayTag = null;
+                var tag;
                 if (!firstNodeHadConn) {
-                    var tag = autoConnectEndpoint(graph.entity(way.nodes[0]), graph.entity(way.id));
+                    tag = autoConnectEndpoint(graph.entity(way.nodes[0]), graph.entity(way.id));
                     if (tag) connectedHighwayTag = tag;
                     way = graph.entity(way.id);  // re-fetch after potential modification
                 }
                 if (!lastNodeHadConn) {
-                    var tag = autoConnectEndpoint(graph.entity(way.nodes[way.nodes.length - 1]), graph.entity(way.id));
+                    tag = autoConnectEndpoint(graph.entity(way.nodes[way.nodes.length - 1]), graph.entity(way.id));
                     if (tag) connectedHighwayTag = tag;
                     way = graph.entity(way.id);  // re-fetch after potential modification
                 }

--- a/modules/core/RapidSystem.js
+++ b/modules/core/RapidSystem.js
@@ -401,7 +401,7 @@ export class RapidSystem extends AbstractSystem {
       const nowAdded = this._addedDatasetIDs.has(datasetID);
       // Ensure that the familiar RAPID_MAGENTA color is used for the ML buildings
       if (!wasAdded && nowAdded && dataset.color === RAPID_MAGENTA) {  // being added right now with the default color
-        if (dataset.categories.has('meta') || dataset.categories.has('microsoft') || dataset.categories.has('google')) {
+        if (dataset.categories.has('meta') || dataset.categories.has('microsoft') || dataset.categories.has('google') || dataset.categories.has('tomtom')) {
           dataset.color = RAPID_MAGENTA;
         } else if (dataset.categories.has('overture')) {
           dataset.color = OVERTURE_CYAN;

--- a/modules/core/RapidSystem.js
+++ b/modules/core/RapidSystem.js
@@ -142,7 +142,7 @@ export class RapidSystem extends AbstractSystem {
 
         // Set some defaults
         if (!urlhash.initialHashParams.has('datasets')) {
-          this._addedDatasetIDs = new Set(['fbRoads', 'esri-buildings', 'ml-buildings-overture', 'omdFootways']);  // on menu
+          this._addedDatasetIDs = new Set(['fbRoads', 'esri-buildings', 'ml-buildings-overture', 'omdFootways', 'tomtom-roads']);  // on menu
           this._enabledDatasetIDs = new Set(['ml-buildings-overture']);  // checked
           this._datasetsChanged();
         }

--- a/modules/pixi/PixiLayerRapid.js
+++ b/modules/pixi/PixiLayerRapid.js
@@ -310,12 +310,28 @@ export class PixiLayerRapid extends AbstractLayer {
           if (entity.type === 'way') {
             data.polygons.push(entity);
           }
+        } else if (datasetID.includes('roads')) {
+          // Lines for roads (OSM entities from OvertureService)
+          if (entity.type === 'way') {
+            data.lines.push(entity);
+            const graph = service.graph(dataset.id);
+            if (graph) {
+              try {
+                const first = graph.entity(entity.first());
+                const last = graph.entity(entity.last());
+                data.vertices.add(first);
+                data.vertices.add(last);
+              } catch (e) {
+                // Skip if we can't resolve endpoint nodes
+              }
+            }
+          }
         }
       }
 
-      // For buildings, we need the graph to resolve node coordinates
-      if (datasetID.includes('buildings')) {
-        dsGraph = service.graph(datasetID);
+      // For buildings and roads, we need the graph to resolve node coordinates
+      if (datasetID.includes('buildings') || datasetID.includes('roads')) {
+        dsGraph = service.graph(dataset.id);
       }
     }
 

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -71,7 +71,7 @@ const MAX_FEATURES_PER_FRAME = 500;
 const BBOX_PAD_DEG = 0.0003;
 
 // Conflation parameters for transportation
-const CONFLATION_THRESHOLD_METERS = 10;   // distance within which a sample point is "near" an OSM highway
+const CONFLATION_THRESHOLD_METERS = 5;    // distance within which a sample point is "near" an OSM highway
 const CONFLATION_REJECT_RATIO = 0.2;      // fraction of near sample points to reject a feature
 const CONFLATION_MAX_SAMPLES = 20;        // maximum sample points along a LineString
 const CONFLATION_MIN_SPACING_METERS = 5;  // minimum spacing between sample points
@@ -823,9 +823,18 @@ export class OvertureService extends AbstractSystem {
     const samplePoints = this._sampleLinePoints(coords, CONFLATION_MAX_SAMPLES, CONFLATION_MIN_SPACING_METERS);
     if (!samplePoints.length) return false;
 
+    // Exclude first and last sample points (endpoints) from the near count.
+    // Diverging roads naturally share proximity at their junction, so counting
+    // endpoints would cause false positives for roads that split off at an angle.
+    const startIdx = samplePoints.length > 2 ? 1 : 0;
+    const endIdx = samplePoints.length > 2 ? samplePoints.length - 1 : samplePoints.length;
+    const interiorCount = endIdx - startIdx;
+    if (interiorCount <= 0) return false;
+
     let nearCount = 0;
 
-    for (const pt of samplePoints) {
+    for (let i = startIdx; i < endIdx; i++) {
+      const pt = samplePoints[i];
       let minDist = Infinity;
       for (const highway of sameModHighways) {
         // Bbox pre-filter
@@ -841,7 +850,7 @@ export class OvertureService extends AbstractSystem {
       if (minDist < CONFLATION_THRESHOLD_METERS) nearCount++;
     }
 
-    return nearCount / samplePoints.length > CONFLATION_REJECT_RATIO;
+    return nearCount / interiorCount > CONFLATION_REJECT_RATIO;
   }
 
 

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -32,8 +32,33 @@ const DEBUG_SOURCES = true;
 const seenSources = new Set();
 
 
+// Source filter for TomTom-sourced transportation data
+const TOMTOM_SOURCES = new Set(['TomTom']);
+
 // Minimum zoom level for loading building data (prevents slowdown at low zooms)
 const MIN_BUILDING_ZOOM = 17;
+
+// Minimum zoom level for loading transportation data
+const MIN_TRANSPORTATION_ZOOM = 16;
+
+// Highway classes grouped by travel mode (used for conflation)
+const MOTORIZED_HIGHWAYS = new Set([
+  'motorway', 'motorway_link', 'trunk', 'trunk_link',
+  'primary', 'primary_link', 'secondary', 'secondary_link',
+  'tertiary', 'tertiary_link', 'residential', 'unclassified',
+  'service', 'road', 'living_street', 'track'
+]);
+const NON_MOTORIZED_HIGHWAYS = new Set([
+  'footway', 'cycleway', 'path', 'pedestrian', 'bridleway', 'steps', 'corridor'
+]);
+
+// Overture class values that map to non-motorized highways
+const NON_MOTORIZED_CLASSES = new Set([
+  'footway', 'cycleway', 'path', 'pedestrian', 'bridleway', 'steps', 'corridor'
+]);
+
+// Highway classes eligible for _link suffix
+const LINK_HIGHWAY_TYPES = new Set(['motorway', 'trunk', 'primary', 'secondary', 'tertiary']);
 
 
 /**
@@ -66,6 +91,11 @@ export class OvertureService extends AbstractSystem {
     this._mlBuildingsGraph = null;
     this._mlBuildingsTree = null;
     this._mlBuildingsCache = { seen: new Set() };
+
+    // For transportation conflation
+    this._tomtomRoadsGraph = null;
+    this._tomtomRoadsTree = null;
+    this._tomtomRoadsCache = { seen: new Set() };
   }
 
 
@@ -94,7 +124,7 @@ export class OvertureService extends AbstractSystem {
       this._releaseId = releaseData.id ?? '';
 
       // 3. Fetch only the themes we need (buildings, places)
-      const WANTED_THEMES = new Set(['buildings', 'places']);
+      const WANTED_THEMES = new Set(['buildings', 'places', 'transportation']);
       const themeLinks = (releaseData.links ?? []).filter(l => l.rel === 'child' && WANTED_THEMES.has(l.title));
       const themeFetches = themeLinks.map(async link => {
         const themeUrl = new URL(link.href, releaseUrl).href;
@@ -151,10 +181,10 @@ export class OvertureService extends AbstractSystem {
 
   /**
    * _invalidateConflationCaches
-   * Clear the "seen" sets so that all Overture buildings get re-conflated
+   * Clear all conflation state so that all Overture features get re-conflated
    * against the latest OSM graph on the next render pass.
-   * We keep the internal graph and tree intact — only the `seen` flags need
-   * resetting so features are re-evaluated for overlap.
+   * Both the `seen` sets and internal graphs/trees are reset to avoid
+   * duplicate entities from re-processing already-rebased features.
    */
   _invalidateConflationCaches() {
     if (this._esriBuildingsCache) {
@@ -169,6 +199,12 @@ export class OvertureService extends AbstractSystem {
     this._esriBuildingsTree = null;
     this._mlBuildingsGraph = null;
     this._mlBuildingsTree = null;
+
+    if (this._tomtomRoadsCache) {
+      this._tomtomRoadsCache.seen.clear();
+    }
+    this._tomtomRoadsGraph = null;
+    this._tomtomRoadsTree = null;
   }
 
 
@@ -186,6 +222,10 @@ export class OvertureService extends AbstractSystem {
     this._mlBuildingsGraph = null;
     this._mlBuildingsTree = null;
     this._mlBuildingsCache = { seen: new Set() };
+
+    this._tomtomRoadsGraph = null;
+    this._tomtomRoadsTree = null;
+    this._tomtomRoadsCache = { seen: new Set() };
 
     return Promise.resolve();
   }
@@ -236,7 +276,20 @@ export class OvertureService extends AbstractSystem {
       descriptionStringID: 'rapid_menu.overture.ml_buildings.description'
     });
 
-    return [places, esriBuildings, mlBuildings];
+    const tomtomRoads = new RapidDataset(this.context, {
+      id: 'tomtom-roads',
+      conflated: false,  // We do client-side conflation
+      service: 'overture',
+      categories: new Set(['overture', 'tomtom', 'roads', 'featured']),
+      color: '#ff6600',  // Orange
+      dataUsed: ['overture', 'TomTom'],
+      itemUrl: 'https://docs.overturemaps.org/guides/transportation/',
+      licenseUrl: 'https://docs.overturemaps.org/attribution/',
+      labelStringID: 'rapid_menu.overture.tomtom_roads.label',
+      descriptionStringID: 'rapid_menu.overture.tomtom_roads.description'
+    });
+
+    return [places, esriBuildings, mlBuildings, tomtomRoads];
   }
 
 
@@ -256,6 +309,12 @@ export class OvertureService extends AbstractSystem {
       if (zoom < MIN_BUILDING_ZOOM) return;
 
       const url = this._pmtilesUrls.get('buildings');
+      if (url) vtService.loadTiles(url);
+    } else if (datasetID === 'tomtom-roads') {
+      const zoom = this.context.viewport.transform.zoom;
+      if (zoom < MIN_TRANSPORTATION_ZOOM) return;
+
+      const url = this._pmtilesUrls.get('transportation');
       if (url) vtService.loadTiles(url);
     }
   }
@@ -289,6 +348,14 @@ export class OvertureService extends AbstractSystem {
       if (!url) return [];
       const geojsonFeatures = vtService.getData(url);
       return this._conflateBuildings(geojsonFeatures, datasetID, ML_SOURCES);
+    } else if (datasetID === 'tomtom-roads') {
+      const zoom = this.context.viewport.transform.zoom;
+      if (zoom < MIN_TRANSPORTATION_ZOOM) return [];
+
+      const url = this._pmtilesUrls.get('transportation');
+      if (!url) return [];
+      const geojsonFeatures = vtService.getData(url);
+      return this._conflateTransportation(geojsonFeatures, datasetID);
     } else {
       return [];
     }
@@ -306,6 +373,8 @@ export class OvertureService extends AbstractSystem {
       return this._esriBuildingsGraph;
     } else if (datasetID === 'ml-buildings-overture') {
       return this._mlBuildingsGraph;
+    } else if (datasetID === 'tomtom-roads') {
+      return this._tomtomRoadsGraph;
     }
     return null;
   }
@@ -564,6 +633,440 @@ export class OvertureService extends AbstractSystem {
     entities.push(way);
 
     return entities;
+  }
+
+
+  /**
+   * _conflateTransportation
+   * Filter out Overture transportation features that overlap with existing OSM highways,
+   * filter by source (TomTom only), and convert remaining features to OSM entities.
+   * Uses mode-aware point-sampling: motorized roads are only conflated against motorized
+   * OSM highways, and non-motorized paths against non-motorized ones.
+   *
+   * @param   {Array}   geojsonFeatures - GeoJSON features from VectorTileService
+   * @param   {string}  datasetID - Which dataset we're processing
+   * @return  {Array}   OSM way entities that pass all filters
+   */
+  _conflateTransportation(geojsonFeatures, datasetID) {
+    if (!geojsonFeatures || !geojsonFeatures.length) return [];
+
+    // Ensure graph/tree/cache exist
+    if (!this._tomtomRoadsGraph) {
+      this._tomtomRoadsGraph = new Graph();
+      this._tomtomRoadsTree = new Tree(this._tomtomRoadsGraph);
+    }
+    const roadsGraph = this._tomtomRoadsGraph;
+    const roadsTree = this._tomtomRoadsTree;
+    const roadsCache = this._tomtomRoadsCache;
+
+    const context = this.context;
+    const editor = context.systems.editor;
+    const osmGraph = editor.staging.graph;
+    const viewport = context.viewport;
+    const extent = viewport.visibleExtent();
+
+    // Get all OSM highway ways in the visible extent
+    const osmEntities = editor.intersects(extent);
+    const motorizedHighways = [];
+    const nonMotorizedHighways = [];
+
+    for (const entity of osmEntities) {
+      if (entity.type !== 'way' || !entity.tags.highway) continue;
+      const hw = entity.tags.highway;
+      try {
+        const nodes = entity.nodes.map(nodeID => osmGraph.entity(nodeID));
+        const coords = nodes.map(n => n.loc);
+        if (coords.length < 2) continue;
+
+        // Compute bbox for fast pre-filtering
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        for (const c of coords) {
+          if (c[0] < minX) minX = c[0];
+          if (c[0] > maxX) maxX = c[0];
+          if (c[1] < minY) minY = c[1];
+          if (c[1] > maxY) maxY = c[1];
+        }
+        // Expand bbox by ~30m in degrees for proximity matching
+        // Using 0.0003 instead of 0.00015 to account for longitude compression at high latitudes
+        const PAD = 0.0003;
+        const data = {
+          coords,
+          bbox: { minX: minX - PAD, minY: minY - PAD, maxX: maxX + PAD, maxY: maxY + PAD }
+        };
+
+        if (MOTORIZED_HIGHWAYS.has(hw)) {
+          motorizedHighways.push(data);
+        } else if (NON_MOTORIZED_HIGHWAYS.has(hw)) {
+          nonMotorizedHighways.push(data);
+        }
+      } catch (e) {
+        continue;
+      }
+    }
+
+    const newEntities = [];
+    const MAX_FEATURES_PER_FRAME = 500;
+    let processedCount = 0;
+
+    for (const feature of geojsonFeatures) {
+      if (processedCount >= MAX_FEATURES_PER_FRAME) break;
+
+      const geojson = feature.geojson;
+      if (!geojson?.geometry) continue;
+
+      const geomType = geojson.geometry.type;
+      if (geomType !== 'LineString' && geomType !== 'MultiLineString') continue;
+
+      const featureID = feature.id || geojson.id;
+      if (roadsCache.seen.has(featureID)) continue;
+      roadsCache.seen.add(featureID);
+      processedCount++;
+
+      // Filter by source — only keep TomTom, reject OSM
+      // Transportation theme uses `sources` array with `dataset` field,
+      // unlike buildings which use `@geometry_source`.
+      const geometrySource = this._getTransportationSource(geojson.properties);
+
+      if (geometrySource && OSM_SOURCES.has(geometrySource)) continue;
+      if (!geometrySource || !TOMTOM_SOURCES.has(geometrySource)) continue;
+
+      // Get line coordinates (handle both LineString and MultiLineString)
+      const lineStrings = geomType === 'LineString'
+        ? [geojson.geometry.coordinates]
+        : geojson.geometry.coordinates;
+
+      // Determine travel mode from Overture class
+      const overtureClass = geojson.properties?.class || '';
+      const isNonMotorized = NON_MOTORIZED_CLASSES.has(overtureClass);
+      const sameModHighways = isNonMotorized ? nonMotorizedHighways : motorizedHighways;
+
+      // Point-sample each linestring and check proximity to same-mode OSM highways
+      let rejected = false;
+      for (const coords of lineStrings) {
+        if (rejected) break;
+        if (!coords || coords.length < 2) continue;
+
+        // Generate sample points along the line
+        const samplePoints = this._sampleLinePoints(coords, 20, 5);
+        if (!samplePoints.length) continue;
+
+        // Count how many sample points are within 10m of a same-mode OSM highway
+        let nearCount = 0;
+        const THRESHOLD_METERS = 10;
+
+        for (const pt of samplePoints) {
+          let minDist = Infinity;
+          for (const highway of sameModHighways) {
+            // Bbox pre-filter
+            if (pt[0] < highway.bbox.minX || pt[0] > highway.bbox.maxX ||
+                pt[1] < highway.bbox.minY || pt[1] > highway.bbox.maxY) {
+              continue;
+            }
+            const dist = this._pointToLineDistance(pt, highway.coords);
+            if (dist < minDist) minDist = dist;
+            if (minDist < THRESHOLD_METERS) break;  // early exit
+          }
+          if (minDist < THRESHOLD_METERS) nearCount++;
+        }
+
+        // If >20% of sample points are near an OSM highway, reject
+        if (nearCount / samplePoints.length > 0.2) {
+          rejected = true;
+        }
+      }
+
+      if (rejected) continue;
+
+      // Convert surviving features to OSM entities
+      for (let j = 0; j < lineStrings.length; j++) {
+        const partID = lineStrings.length > 1 ? `${featureID}-p${j}` : featureID;
+        const entities = this._geojsonToOSMLine(lineStrings[j], geojson.properties, partID, datasetID, geometrySource);
+        if (entities) {
+          newEntities.push(...entities);
+        }
+      }
+    }
+
+    // Update the internal graph with new entities
+    if (newEntities.length) {
+      roadsGraph.rebase(newEntities, [roadsGraph], true);
+      roadsTree.rebase(newEntities, true);
+    }
+
+    // Return ways from the tree that intersect the visible extent
+    return roadsTree.intersects(extent, roadsGraph)
+      .filter(entity => entity.type === 'way');
+  }
+
+
+  /**
+   * _sampleLinePoints
+   * Generate sample points along a LineString at regular intervals.
+   * @param   {Array}   coords - Array of [lon, lat] coordinates
+   * @param   {number}  maxSamples - Maximum number of sample points
+   * @param   {number}  minSpacingMeters - Minimum spacing between samples in meters
+   * @return  {Array}   Array of [lon, lat] sample points
+   */
+  _sampleLinePoints(coords, maxSamples, minSpacingMeters) {
+    if (!coords || coords.length < 2) return [];
+
+    // Compute approximate total length in meters
+    let totalLength = 0;
+    for (let i = 1; i < coords.length; i++) {
+      totalLength += this._distMeters(coords[i - 1], coords[i]);
+    }
+
+    if (totalLength === 0) return [coords[0]];
+
+    // Determine number of samples
+    const maxBySpacing = Math.floor(totalLength / minSpacingMeters) + 1;
+    const numSamples = Math.min(maxSamples, maxBySpacing);
+    if (numSamples <= 1) return [coords[0]];
+
+    const spacing = totalLength / (numSamples - 1);
+    const samples = [];
+    let accumulated = 0;
+    let nextSampleDist = 0;
+
+    samples.push(coords[0]);
+    nextSampleDist = spacing;
+
+    for (let i = 1; i < coords.length && samples.length < numSamples; i++) {
+      const segLen = this._distMeters(coords[i - 1], coords[i]);
+      const prevAccum = accumulated;
+      accumulated += segLen;
+
+      while (nextSampleDist <= accumulated && samples.length < numSamples) {
+        const t = (segLen > 0) ? (nextSampleDist - prevAccum) / segLen : 0;
+        const lon = coords[i - 1][0] + t * (coords[i][0] - coords[i - 1][0]);
+        const lat = coords[i - 1][1] + t * (coords[i][1] - coords[i - 1][1]);
+        samples.push([lon, lat]);
+        nextSampleDist += spacing;
+      }
+    }
+
+    return samples;
+  }
+
+
+  /**
+   * _distMeters
+   * Flat-earth distance approximation between two [lon, lat] points.
+   * Sufficient for distances under ~1km.
+   * @param   {Array}  a - [lon, lat]
+   * @param   {Array}  b - [lon, lat]
+   * @return  {number} Distance in meters
+   */
+  _distMeters(a, b) {
+    const DEG_TO_M = 111320;
+    const dLon = (b[0] - a[0]) * Math.cos((a[1] + b[1]) * Math.PI / 360);
+    const dLat = b[1] - a[1];
+    return Math.sqrt(dLon * dLon + dLat * dLat) * DEG_TO_M;
+  }
+
+
+  /**
+   * _pointToLineDistance
+   * Compute minimum distance in meters from a point to a polyline.
+   * @param   {Array}  pt - [lon, lat]
+   * @param   {Array}  lineCoords - Array of [lon, lat] for the polyline
+   * @return  {number} Minimum distance in meters
+   */
+  _pointToLineDistance(pt, lineCoords) {
+    let minDist = Infinity;
+    for (let i = 0; i < lineCoords.length - 1; i++) {
+      const dist = this._pointToSegmentDistance(pt, lineCoords[i], lineCoords[i + 1]);
+      if (dist < minDist) minDist = dist;
+      if (minDist === 0) return 0;
+    }
+    return minDist;
+  }
+
+
+  /**
+   * _pointToSegmentDistance
+   * Compute distance in meters from a point to a line segment.
+   * @param   {Array}  pt - [lon, lat]
+   * @param   {Array}  a - [lon, lat] segment start
+   * @param   {Array}  b - [lon, lat] segment end
+   * @return  {number} Distance in meters
+   */
+  _pointToSegmentDistance(pt, a, b) {
+    const cosLat = Math.cos((pt[1] + a[1] + b[1]) / 3 * Math.PI / 180);
+    const dx = (b[0] - a[0]) * cosLat;
+    const dy = b[1] - a[1];
+    const lenSq = dx * dx + dy * dy;
+
+    let t = 0;
+    if (lenSq > 0) {
+      const px = (pt[0] - a[0]) * cosLat;
+      const py = pt[1] - a[1];
+      t = Math.max(0, Math.min(1, (px * dx + py * dy) / lenSq));
+    }
+
+    const projLon = a[0] + t * (b[0] - a[0]);
+    const projLat = a[1] + t * (b[1] - a[1]);
+    return this._distMeters(pt, [projLon, projLat]);
+  }
+
+
+  /**
+   * _getTransportationSource
+   * Extract the primary source dataset name from transportation feature properties.
+   * Transportation features use a `sources` array with `dataset` fields,
+   * unlike buildings which use `@geometry_source`.
+   * The `sources` property may be a JSON string (from MVT encoding) or an array.
+   * @param   {Object}  props - Feature properties
+   * @return  {string|null}  Source dataset name (e.g. 'TomTom', 'OpenStreetMap'), or null
+   */
+  _getTransportationSource(props) {
+    if (!props) return null;
+
+    // Try `@geometry_source` first (buildings-style)
+    if (props['@geometry_source']) return props['@geometry_source'];
+
+    // Transportation uses `sources` array with `dataset` field
+    let sources = props.sources;
+    if (!sources) return null;
+
+    // MVT may encode arrays as JSON strings
+    if (typeof sources === 'string') {
+      try { sources = JSON.parse(sources); } catch (e) { return null; }
+    }
+
+    if (Array.isArray(sources) && sources.length > 0) {
+      return sources[0].dataset || null;
+    }
+
+    return null;
+  }
+
+
+  /**
+   * _geojsonToOSMLine
+   * Convert a LineString's coordinates to osmNode/osmWay entities
+   * @param   {Array}   coords - Array of [lon, lat] coordinates
+   * @param   {Object}  properties - GeoJSON feature properties
+   * @param   {string}  featureID - Unique identifier for this feature
+   * @param   {string}  datasetID - The dataset this feature belongs to
+   * @param   {string}  geometrySource - The @geometry_source value
+   * @return  {Array}   Array of [osmNodes..., osmWay], or null if invalid
+   */
+  _geojsonToOSMLine(coords, properties, featureID, datasetID, geometrySource) {
+    if (!coords || coords.length < 2) return null;
+
+    const entities = [];
+    const nodeIDs = [];
+
+    for (let i = 0; i < coords.length; i++) {
+      const loc = coords[i];
+      const nodeID = osmEntity.id('node');
+
+      const node = new osmNode({
+        id: nodeID,
+        loc: loc,
+        tags: {}
+      });
+
+      node.__fbid__ = `${datasetID}-${featureID}-n${i}`;
+      node.__service__ = 'overture';
+      node.__datasetid__ = datasetID;
+
+      entities.push(node);
+      nodeIDs.push(nodeID);
+    }
+
+    // Build tags from Overture transportation properties
+    const tags = this._mapOvertureTransportationTags(properties || {});
+
+    const wayID = osmEntity.id('way');
+    const way = new osmWay({
+      id: wayID,
+      nodes: nodeIDs,
+      tags: tags
+    });
+
+    way.__fbid__ = `${datasetID}-${featureID}`;
+    way.__service__ = 'overture';
+    way.__datasetid__ = datasetID;
+    way.__gersid__ = (properties || {}).id || null;
+
+    entities.push(way);
+    return entities;
+  }
+
+
+  /**
+   * _mapOvertureTransportationTags
+   * Map Overture transportation properties to OSM tags.
+   * PMTiles MVT may encode nested properties differently than the raw schema,
+   * so this includes fallback handling for flattened property names.
+   *
+   * @param   {Object}  props - Feature properties from Overture PMTiles
+   * @return  {Object}  OSM tags
+   */
+  _mapOvertureTransportationTags(props) {
+    const tags = {};
+
+    // highway= from class
+    let highwayClass = props.class || '';
+    if (highwayClass === 'unknown') {
+      highwayClass = 'road';  // TomTom-sourced unknowns → road (OSM equivalent for unknown classification)
+    }
+
+    // Check for _link subclass
+    const subclassRules = props.subclass_rules || props.subclass || [];
+    let isLink = false;
+    let footwayValue = null;
+    if (Array.isArray(subclassRules)) {
+      for (const rule of subclassRules) {
+        const val = rule?.value || rule;
+        if (val === 'link') isLink = true;
+        if (val === 'sidewalk') footwayValue = 'sidewalk';
+        if (val === 'crosswalk') footwayValue = 'crossing';
+      }
+    } else if (typeof subclassRules === 'string') {
+      if (subclassRules === 'link') isLink = true;
+      if (subclassRules === 'sidewalk') footwayValue = 'sidewalk';
+      if (subclassRules === 'crosswalk') footwayValue = 'crossing';
+    }
+
+    if (highwayClass) {
+      if (isLink && LINK_HIGHWAY_TYPES.has(highwayClass)) {
+        tags.highway = highwayClass + '_link';
+      } else {
+        tags.highway = highwayClass;
+      }
+    }
+
+    // footway= from subclass
+    if (footwayValue && tags.highway === 'footway') {
+      tags.footway = footwayValue;
+    }
+
+    // surface= from road_surface
+    const roadSurface = props.road_surface || props.surface || [];
+    const SURFACE_MAP = {
+      'paved': 'paved',
+      'unpaved': 'unpaved',
+      'gravel': 'gravel',
+      'dirt': 'dirt',
+      'paving_stones': 'paving_stones',
+      'metal': 'metal'
+    };
+    if (Array.isArray(roadSurface) && roadSurface.length > 0) {
+      const surfVal = roadSurface[0]?.value || roadSurface[0];
+      if (surfVal && SURFACE_MAP[surfVal]) {
+        tags.surface = SURFACE_MAP[surfVal];
+      }
+    } else if (typeof roadSurface === 'string' && SURFACE_MAP[roadSurface]) {
+      tags.surface = SURFACE_MAP[roadSurface];
+    }
+
+    // source — safe to hardcode because _conflateTransportation filters to TomTom-only
+    tags.source = 'TomTom';
+
+    return tags;
   }
 
 }

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -1,5 +1,5 @@
 import * as Polyclip from 'polyclip-ts';
-import { geoSphericalClosestPoint, geoSphericalDistance } from '@rapid-sdk/math';
+import { geoSphericalDistance, vecProject } from '@rapid-sdk/math';
 
 import { AbstractSystem } from '../core/AbstractSystem.js';
 import { Graph, Tree, RapidDataset } from '../core/lib/index.js';
@@ -842,8 +842,7 @@ export class OvertureService extends AbstractSystem {
             pt[1] < highway.bbox.minY || pt[1] > highway.bbox.maxY) {
           continue;
         }
-        const closest = geoSphericalClosestPoint(highway.coords, pt);
-        const dist = closest?.distance ?? Infinity;
+        const dist = this._distToPolylineMeters(pt, highway.coords);
         if (dist < minDist) minDist = dist;
         if (minDist < CONFLATION_THRESHOLD_METERS) break;  // early exit
       }
@@ -901,6 +900,25 @@ export class OvertureService extends AbstractSystem {
     }
 
     return samples;
+  }
+
+
+  /**
+   * _distToPolylineMeters
+   * Compute the minimum distance in meters from a point to any segment of a polyline.
+   * Uses vecProject for segment projection, then geoSphericalDistance for the metric.
+   *
+   * @param   {Array}   pt - [lon, lat] point
+   * @param   {Array}   coords - Array of [lon, lat] polyline vertices
+   * @return  {number}  Minimum distance in meters
+   */
+  _distToPolylineMeters(pt, coords) {
+    if (!coords || coords.length === 0) return Infinity;
+    if (coords.length === 1) return geoSphericalDistance(pt, coords[0]);
+
+    const edge = vecProject(pt, coords);
+    if (!edge) return Infinity;
+    return geoSphericalDistance(pt, edge.target);
   }
 
 

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -1,4 +1,5 @@
 import * as Polyclip from 'polyclip-ts';
+import { geoSphericalClosestPoint, geoSphericalDistance } from '@rapid-sdk/math';
 
 import { AbstractSystem } from '../core/AbstractSystem.js';
 import { Graph, Tree, RapidDataset } from '../core/lib/index.js';
@@ -59,6 +60,31 @@ const NON_MOTORIZED_CLASSES = new Set([
 
 // Highway classes eligible for _link suffix
 const LINK_HIGHWAY_TYPES = new Set(['motorway', 'trunk', 'primary', 'secondary', 'tertiary']);
+
+// STAC themes to fetch PMTiles URLs for
+const WANTED_THEMES = new Set(['buildings', 'places', 'transportation']);
+
+// Maximum features to process per render frame (prevents main thread blocking)
+const MAX_FEATURES_PER_FRAME = 500;
+
+// Bbox padding in degrees for proximity matching (~30m, enlarged to account for longitude compression at high latitudes)
+const BBOX_PAD_DEG = 0.0003;
+
+// Conflation parameters for transportation
+const CONFLATION_THRESHOLD_METERS = 10;   // distance within which a sample point is "near" an OSM highway
+const CONFLATION_REJECT_RATIO = 0.2;      // fraction of near sample points to reject a feature
+const CONFLATION_MAX_SAMPLES = 20;        // maximum sample points along a LineString
+const CONFLATION_MIN_SPACING_METERS = 5;  // minimum spacing between sample points
+
+// Map Overture road_surface values to OSM surface= tag values
+const SURFACE_MAP = {
+  'paved': 'paved',
+  'unpaved': 'unpaved',
+  'gravel': 'gravel',
+  'dirt': 'dirt',
+  'paving_stones': 'paving_stones',
+  'metal': 'metal'
+};
 
 
 /**
@@ -123,8 +149,7 @@ export class OvertureService extends AbstractSystem {
       const releaseData = await fetch(releaseUrl).then(utilFetchResponse);
       this._releaseId = releaseData.id ?? '';
 
-      // 3. Fetch only the themes we need (buildings, places)
-      const WANTED_THEMES = new Set(['buildings', 'places', 'transportation']);
+      // 3. Fetch only the themes we need
       const themeLinks = (releaseData.links ?? []).filter(l => l.rel === 'child' && WANTED_THEMES.has(l.title));
       const themeFetches = themeLinks.map(async link => {
         const themeUrl = new URL(link.href, releaseUrl).href;
@@ -463,7 +488,6 @@ export class OvertureService extends AbstractSystem {
     const newEntities = [];
 
     // Limit processing to avoid blocking the main thread
-    const MAX_FEATURES_PER_FRAME = 500;
     let processedCount = 0;
 
     for (const feature of geojsonFeatures) {
@@ -660,52 +684,12 @@ export class OvertureService extends AbstractSystem {
     const roadsCache = this._tomtomRoadsCache;
 
     const context = this.context;
-    const editor = context.systems.editor;
-    const osmGraph = editor.staging.graph;
     const viewport = context.viewport;
     const extent = viewport.visibleExtent();
 
-    // Get all OSM highway ways in the visible extent
-    const osmEntities = editor.intersects(extent);
-    const motorizedHighways = [];
-    const nonMotorizedHighways = [];
-
-    for (const entity of osmEntities) {
-      if (entity.type !== 'way' || !entity.tags.highway) continue;
-      const hw = entity.tags.highway;
-      try {
-        const nodes = entity.nodes.map(nodeID => osmGraph.entity(nodeID));
-        const coords = nodes.map(n => n.loc);
-        if (coords.length < 2) continue;
-
-        // Compute bbox for fast pre-filtering
-        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-        for (const c of coords) {
-          if (c[0] < minX) minX = c[0];
-          if (c[0] > maxX) maxX = c[0];
-          if (c[1] < minY) minY = c[1];
-          if (c[1] > maxY) maxY = c[1];
-        }
-        // Expand bbox by ~30m in degrees for proximity matching
-        // Using 0.0003 instead of 0.00015 to account for longitude compression at high latitudes
-        const PAD = 0.0003;
-        const data = {
-          coords,
-          bbox: { minX: minX - PAD, minY: minY - PAD, maxX: maxX + PAD, maxY: maxY + PAD }
-        };
-
-        if (MOTORIZED_HIGHWAYS.has(hw)) {
-          motorizedHighways.push(data);
-        } else if (NON_MOTORIZED_HIGHWAYS.has(hw)) {
-          nonMotorizedHighways.push(data);
-        }
-      } catch (e) {
-        continue;
-      }
-    }
+    const { motorized, nonMotorized } = this._getOSMHighwaysByMode(extent);
 
     const newEntities = [];
-    const MAX_FEATURES_PER_FRAME = 500;
     let processedCount = 0;
 
     for (const feature of geojsonFeatures) {
@@ -738,39 +722,13 @@ export class OvertureService extends AbstractSystem {
       // Determine travel mode from Overture class
       const overtureClass = geojson.properties?.class || '';
       const isNonMotorized = NON_MOTORIZED_CLASSES.has(overtureClass);
-      const sameModHighways = isNonMotorized ? nonMotorizedHighways : motorizedHighways;
+      const sameModHighways = isNonMotorized ? nonMotorized : motorized;
 
-      // Point-sample each linestring and check proximity to same-mode OSM highways
+      // Check if any linestring in this feature is conflated with existing OSM
       let rejected = false;
       for (const coords of lineStrings) {
         if (rejected) break;
-        if (!coords || coords.length < 2) continue;
-
-        // Generate sample points along the line
-        const samplePoints = this._sampleLinePoints(coords, 20, 5);
-        if (!samplePoints.length) continue;
-
-        // Count how many sample points are within 10m of a same-mode OSM highway
-        let nearCount = 0;
-        const THRESHOLD_METERS = 10;
-
-        for (const pt of samplePoints) {
-          let minDist = Infinity;
-          for (const highway of sameModHighways) {
-            // Bbox pre-filter
-            if (pt[0] < highway.bbox.minX || pt[0] > highway.bbox.maxX ||
-                pt[1] < highway.bbox.minY || pt[1] > highway.bbox.maxY) {
-              continue;
-            }
-            const dist = this._pointToLineDistance(pt, highway.coords);
-            if (dist < minDist) minDist = dist;
-            if (minDist < THRESHOLD_METERS) break;  // early exit
-          }
-          if (minDist < THRESHOLD_METERS) nearCount++;
-        }
-
-        // If >20% of sample points are near an OSM highway, reject
-        if (nearCount / samplePoints.length > 0.2) {
+        if (this._isConflatedWithOSM(coords, sameModHighways)) {
           rejected = true;
         }
       }
@@ -800,6 +758,94 @@ export class OvertureService extends AbstractSystem {
 
 
   /**
+   * _getOSMHighwaysByMode
+   * Collect existing OSM highway ways in the given extent, categorized by travel mode.
+   * Each highway entry includes its coordinates and a padded bounding box for fast filtering.
+   *
+   * @param   {Object}  extent - Visible extent from the viewport
+   * @return  {Object}  `{ motorized, nonMotorized }` arrays of `{ coords, bbox }` objects
+   */
+  _getOSMHighwaysByMode(extent) {
+    const editor = this.context.systems.editor;
+    const osmGraph = editor.staging.graph;
+    const osmEntities = editor.intersects(extent);
+    const motorized = [];
+    const nonMotorized = [];
+
+    for (const entity of osmEntities) {
+      if (entity.type !== 'way' || !entity.tags.highway) continue;
+      const hw = entity.tags.highway;
+      try {
+        const nodes = entity.nodes.map(nodeID => osmGraph.entity(nodeID));
+        const coords = nodes.map(n => n.loc);
+        if (coords.length < 2) continue;
+
+        // Compute bbox for fast pre-filtering
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        for (const c of coords) {
+          if (c[0] < minX) minX = c[0];
+          if (c[0] > maxX) maxX = c[0];
+          if (c[1] < minY) minY = c[1];
+          if (c[1] > maxY) maxY = c[1];
+        }
+        const data = {
+          coords,
+          bbox: { minX: minX - BBOX_PAD_DEG, minY: minY - BBOX_PAD_DEG, maxX: maxX + BBOX_PAD_DEG, maxY: maxY + BBOX_PAD_DEG }
+        };
+
+        if (MOTORIZED_HIGHWAYS.has(hw)) {
+          motorized.push(data);
+        } else if (NON_MOTORIZED_HIGHWAYS.has(hw)) {
+          nonMotorized.push(data);
+        }
+      } catch (e) {
+        continue;
+      }
+    }
+
+    return { motorized, nonMotorized };
+  }
+
+
+  /**
+   * _isConflatedWithOSM
+   * Determine whether a LineString is already represented by existing OSM highways.
+   * Uses point-sampling: if >20% of sample points along the line are within 10m of
+   * a same-mode OSM highway, the feature is considered conflated.
+   *
+   * @param   {Array}   coords - Array of [lon, lat] coordinates for the LineString
+   * @param   {Array}   sameModHighways - Array of `{ coords, bbox }` for same-mode OSM highways
+   * @return  {boolean} true if the line is conflated (should be rejected)
+   */
+  _isConflatedWithOSM(coords, sameModHighways) {
+    if (!coords || coords.length < 2) return false;
+
+    const samplePoints = this._sampleLinePoints(coords, CONFLATION_MAX_SAMPLES, CONFLATION_MIN_SPACING_METERS);
+    if (!samplePoints.length) return false;
+
+    let nearCount = 0;
+
+    for (const pt of samplePoints) {
+      let minDist = Infinity;
+      for (const highway of sameModHighways) {
+        // Bbox pre-filter
+        if (pt[0] < highway.bbox.minX || pt[0] > highway.bbox.maxX ||
+            pt[1] < highway.bbox.minY || pt[1] > highway.bbox.maxY) {
+          continue;
+        }
+        const closest = geoSphericalClosestPoint(highway.coords, pt);
+        const dist = closest?.distance ?? Infinity;
+        if (dist < minDist) minDist = dist;
+        if (minDist < CONFLATION_THRESHOLD_METERS) break;  // early exit
+      }
+      if (minDist < CONFLATION_THRESHOLD_METERS) nearCount++;
+    }
+
+    return nearCount / samplePoints.length > CONFLATION_REJECT_RATIO;
+  }
+
+
+  /**
    * _sampleLinePoints
    * Generate sample points along a LineString at regular intervals.
    * @param   {Array}   coords - Array of [lon, lat] coordinates
@@ -813,7 +859,7 @@ export class OvertureService extends AbstractSystem {
     // Compute approximate total length in meters
     let totalLength = 0;
     for (let i = 1; i < coords.length; i++) {
-      totalLength += this._distMeters(coords[i - 1], coords[i]);
+      totalLength += geoSphericalDistance(coords[i - 1], coords[i]);
     }
 
     if (totalLength === 0) return [coords[0]];
@@ -832,7 +878,7 @@ export class OvertureService extends AbstractSystem {
     nextSampleDist = spacing;
 
     for (let i = 1; i < coords.length && samples.length < numSamples; i++) {
-      const segLen = this._distMeters(coords[i - 1], coords[i]);
+      const segLen = geoSphericalDistance(coords[i - 1], coords[i]);
       const prevAccum = accumulated;
       accumulated += segLen;
 
@@ -850,67 +896,6 @@ export class OvertureService extends AbstractSystem {
 
 
   /**
-   * _distMeters
-   * Flat-earth distance approximation between two [lon, lat] points.
-   * Sufficient for distances under ~1km.
-   * @param   {Array}  a - [lon, lat]
-   * @param   {Array}  b - [lon, lat]
-   * @return  {number} Distance in meters
-   */
-  _distMeters(a, b) {
-    const DEG_TO_M = 111320;
-    const dLon = (b[0] - a[0]) * Math.cos((a[1] + b[1]) * Math.PI / 360);
-    const dLat = b[1] - a[1];
-    return Math.sqrt(dLon * dLon + dLat * dLat) * DEG_TO_M;
-  }
-
-
-  /**
-   * _pointToLineDistance
-   * Compute minimum distance in meters from a point to a polyline.
-   * @param   {Array}  pt - [lon, lat]
-   * @param   {Array}  lineCoords - Array of [lon, lat] for the polyline
-   * @return  {number} Minimum distance in meters
-   */
-  _pointToLineDistance(pt, lineCoords) {
-    let minDist = Infinity;
-    for (let i = 0; i < lineCoords.length - 1; i++) {
-      const dist = this._pointToSegmentDistance(pt, lineCoords[i], lineCoords[i + 1]);
-      if (dist < minDist) minDist = dist;
-      if (minDist === 0) return 0;
-    }
-    return minDist;
-  }
-
-
-  /**
-   * _pointToSegmentDistance
-   * Compute distance in meters from a point to a line segment.
-   * @param   {Array}  pt - [lon, lat]
-   * @param   {Array}  a - [lon, lat] segment start
-   * @param   {Array}  b - [lon, lat] segment end
-   * @return  {number} Distance in meters
-   */
-  _pointToSegmentDistance(pt, a, b) {
-    const cosLat = Math.cos((pt[1] + a[1] + b[1]) / 3 * Math.PI / 180);
-    const dx = (b[0] - a[0]) * cosLat;
-    const dy = b[1] - a[1];
-    const lenSq = dx * dx + dy * dy;
-
-    let t = 0;
-    if (lenSq > 0) {
-      const px = (pt[0] - a[0]) * cosLat;
-      const py = pt[1] - a[1];
-      t = Math.max(0, Math.min(1, (px * dx + py * dy) / lenSq));
-    }
-
-    const projLon = a[0] + t * (b[0] - a[0]);
-    const projLat = a[1] + t * (b[1] - a[1]);
-    return this._distMeters(pt, [projLon, projLat]);
-  }
-
-
-  /**
    * _getTransportationSource
    * Extract the primary source dataset name from transportation feature properties.
    * Transportation features use a `sources` array with `dataset` fields,
@@ -921,9 +906,6 @@ export class OvertureService extends AbstractSystem {
    */
   _getTransportationSource(props) {
     if (!props) return null;
-
-    // Try `@geometry_source` first (buildings-style)
-    if (props['@geometry_source']) return props['@geometry_source'];
 
     // Transportation uses `sources` array with `dataset` field
     let sources = props.sources;
@@ -1046,14 +1028,6 @@ export class OvertureService extends AbstractSystem {
 
     // surface= from road_surface
     const roadSurface = props.road_surface || props.surface || [];
-    const SURFACE_MAP = {
-      'paved': 'paved',
-      'unpaved': 'unpaved',
-      'gravel': 'gravel',
-      'dirt': 'dirt',
-      'paving_stones': 'paving_stones',
-      'metal': 'metal'
-    };
     if (Array.isArray(roadSurface) && roadSurface.length > 0) {
       const surfVal = roadSurface[0]?.value || roadSurface[0];
       if (surfVal && SURFACE_MAP[surfVal]) {

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -306,7 +306,7 @@ export class OvertureService extends AbstractSystem {
       conflated: false,  // We do client-side conflation
       service: 'overture',
       categories: new Set(['overture', 'tomtom', 'roads', 'featured']),
-      color: '#ff6600',  // Orange
+      color: '#da26d3',  // Rapid magenta
       dataUsed: ['overture', 'TomTom'],
       itemUrl: 'https://docs.overturemaps.org/guides/transportation/',
       licenseUrl: 'https://docs.overturemaps.org/attribution/',

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -810,7 +810,7 @@ export class OvertureService extends AbstractSystem {
   /**
    * _isConflatedWithOSM
    * Determine whether a LineString is already represented by existing OSM highways.
-   * Uses point-sampling: if >20% of sample points along the line are within 10m of
+   * Uses point-sampling: if >20% of sample points along the line are within 5m of
    * a same-mode OSM highway, the feature is considered conflated.
    *
    * @param   {Array}   coords - Array of [lon, lat] coordinates for the LineString

--- a/modules/services/OvertureService.js
+++ b/modules/services/OvertureService.js
@@ -738,7 +738,7 @@ export class OvertureService extends AbstractSystem {
       // Convert surviving features to OSM entities
       for (let j = 0; j < lineStrings.length; j++) {
         const partID = lineStrings.length > 1 ? `${featureID}-p${j}` : featureID;
-        const entities = this._geojsonToOSMLine(lineStrings[j], geojson.properties, partID, datasetID, geometrySource);
+        const entities = this._geojsonToOSMLine(lineStrings[j], geojson.properties, partID, datasetID);
         if (entities) {
           newEntities.push(...entities);
         }
@@ -958,10 +958,9 @@ export class OvertureService extends AbstractSystem {
    * @param   {Object}  properties - GeoJSON feature properties
    * @param   {string}  featureID - Unique identifier for this feature
    * @param   {string}  datasetID - The dataset this feature belongs to
-   * @param   {string}  geometrySource - The @geometry_source value
    * @return  {Array}   Array of [osmNodes..., osmWay], or null if invalid
    */
-  _geojsonToOSMLine(coords, properties, featureID, datasetID, geometrySource) {
+  _geojsonToOSMLine(coords, properties, featureID, datasetID) {
     if (!coords || coords.length < 2) return null;
 
     const entities = [];

--- a/modules/ui/UiRapidInspector.js
+++ b/modules/ui/UiRapidInspector.js
@@ -199,7 +199,7 @@ export class UiRapidInspector {
       dataUsed: dataset?.dataUsed || [datasetID]
     };
 
-    editor.perform(actionRapidAcceptFeature(datum.id, graph));
+    editor.perform(actionRapidAcceptFeature(datum.id, graph, editor.tree));
     editor.commit({ annotation: annotation, selectedIDs: [datum.id] });
 
     // What next

--- a/test/browser/services/OvertureService.test.js
+++ b/test/browser/services/OvertureService.test.js
@@ -367,7 +367,8 @@ describe('OvertureService', () => {
           visibleExtent: () => ({
             min: [-180, -90],
             max: [180, 90],
-            rectangle: () => [-180, -90, 180, 90]
+            rectangle: () => [-180, -90, 180, 90],
+            bbox: () => ({ minX: -180, minY: -90, maxX: 180, maxY: 90 })
           })
         }
       };

--- a/test/browser/services/OvertureService.test.js
+++ b/test/browser/services/OvertureService.test.js
@@ -81,4 +81,476 @@ describe('OvertureService', () => {
     });
   });
 
+
+  describe('#_geojsonToOSMLine', () => {
+    it('creates an open way from LineString coordinates', () => {
+      const coords = [[0, 0], [1, 0], [1, 1]];
+      const props = { class: 'residential', id: 'gers-123' };
+      const entities = overture._geojsonToOSMLine(coords, props, 'feat1', 'tomtom-roads', 'TomTom');
+      const way = entities[entities.length - 1];
+
+      // 3 coords → 3 nodes, way should NOT be closed
+      expect(way.nodes.length).to.eql(3);
+      expect(way.nodes[0]).to.not.eql(way.nodes[2]);
+    });
+
+    it('sets metadata on nodes and way', () => {
+      const coords = [[0, 0], [1, 0]];
+      const props = { class: 'residential', id: 'gers-456' };
+      const entities = overture._geojsonToOSMLine(coords, props, 'feat1', 'tomtom-roads', 'TomTom');
+      const way = entities[entities.length - 1];
+      const node = entities[0];
+
+      expect(way.__fbid__).to.eql('tomtom-roads-feat1');
+      expect(way.__service__).to.eql('overture');
+      expect(way.__datasetid__).to.eql('tomtom-roads');
+      expect(way.__gersid__).to.eql('gers-456');
+
+      expect(node.__fbid__).to.eql('tomtom-roads-feat1-n0');
+      expect(node.__service__).to.eql('overture');
+      expect(node.__datasetid__).to.eql('tomtom-roads');
+    });
+
+    it('applies tag mapping from properties', () => {
+      const coords = [[0, 0], [1, 0]];
+      const props = { class: 'primary' };
+      const entities = overture._geojsonToOSMLine(coords, props, 'feat1', 'tomtom-roads', 'TomTom');
+      const way = entities[entities.length - 1];
+      expect(way.tags.highway).to.eql('primary');
+      expect(way.tags.source).to.eql('TomTom');
+    });
+
+    it('returns null for too few coordinates', () => {
+      expect(overture._geojsonToOSMLine([[0, 0]], {}, 'feat1', 'tomtom-roads', 'TomTom')).to.be.null;
+    });
+
+    it('returns null for null coords', () => {
+      expect(overture._geojsonToOSMLine(null, {}, 'feat1', 'tomtom-roads', 'TomTom')).to.be.null;
+    });
+  });
+
+
+  describe('#_getTransportationSource', () => {
+    it('returns source from @geometry_source property', () => {
+      expect(overture._getTransportationSource({ '@geometry_source': 'TomTom' })).to.eql('TomTom');
+    });
+
+    it('returns source from sources array with dataset field', () => {
+      expect(overture._getTransportationSource({
+        sources: [{ dataset: 'TomTom', license: 'ODbL-1.0' }]
+      })).to.eql('TomTom');
+    });
+
+    it('parses sources when encoded as JSON string', () => {
+      expect(overture._getTransportationSource({
+        sources: '[{"dataset":"TomTom","license":"ODbL-1.0"}]'
+      })).to.eql('TomTom');
+    });
+
+    it('returns null for missing properties', () => {
+      expect(overture._getTransportationSource(null)).to.be.null;
+      expect(overture._getTransportationSource({})).to.be.null;
+    });
+
+    it('returns null for empty sources array', () => {
+      expect(overture._getTransportationSource({ sources: [] })).to.be.null;
+    });
+
+    it('returns null for malformed JSON string', () => {
+      expect(overture._getTransportationSource({ sources: 'not-json' })).to.be.null;
+    });
+
+    it('prefers @geometry_source over sources array', () => {
+      expect(overture._getTransportationSource({
+        '@geometry_source': 'Google',
+        sources: [{ dataset: 'TomTom' }]
+      })).to.eql('Google');
+    });
+  });
+
+
+  describe('#_mapOvertureTransportationTags', () => {
+    it('maps basic highway class', () => {
+      const tags = overture._mapOvertureTransportationTags({ class: 'residential' });
+      expect(tags.highway).to.eql('residential');
+      expect(tags.source).to.eql('TomTom');
+    });
+
+    it('maps unknown class to road', () => {
+      const tags = overture._mapOvertureTransportationTags({ class: 'unknown' });
+      expect(tags.highway).to.eql('road');
+    });
+
+    it('appends _link for link subclass', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'motorway',
+        subclass_rules: [{ value: 'link' }]
+      });
+      expect(tags.highway).to.eql('motorway_link');
+    });
+
+    it('does not append _link for non-link types', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'residential',
+        subclass_rules: [{ value: 'link' }]
+      });
+      // residential is not in the linkTypes set
+      expect(tags.highway).to.eql('residential');
+    });
+
+    it('handles subclass_rules as a string', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'primary',
+        subclass_rules: 'link'
+      });
+      expect(tags.highway).to.eql('primary_link');
+    });
+
+    it('maps sidewalk subclass to footway=sidewalk', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'footway',
+        subclass_rules: [{ value: 'sidewalk' }]
+      });
+      expect(tags.highway).to.eql('footway');
+      expect(tags.footway).to.eql('sidewalk');
+    });
+
+    it('maps crosswalk subclass to footway=crossing', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'footway',
+        subclass_rules: [{ value: 'crosswalk' }]
+      });
+      expect(tags.footway).to.eql('crossing');
+    });
+
+    it('does not set footway tag if highway is not footway', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'residential',
+        subclass_rules: [{ value: 'sidewalk' }]
+      });
+      expect(tags.footway).to.be.undefined;
+    });
+
+    it('maps road_surface to surface tag', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'residential',
+        road_surface: [{ value: 'gravel' }]
+      });
+      expect(tags.surface).to.eql('gravel');
+    });
+
+    it('handles surface as a string fallback', () => {
+      const tags = overture._mapOvertureTransportationTags({
+        class: 'residential',
+        surface: 'paved'
+      });
+      expect(tags.surface).to.eql('paved');
+    });
+
+    it('always sets source=TomTom', () => {
+      const tags = overture._mapOvertureTransportationTags({});
+      expect(tags.source).to.eql('TomTom');
+    });
+  });
+
+
+  describe('#_sampleLinePoints', () => {
+    it('returns empty for less than 2 coords', () => {
+      expect(overture._sampleLinePoints([[0, 0]], 20, 5)).to.eql([]);
+      expect(overture._sampleLinePoints([], 20, 5)).to.eql([]);
+      expect(overture._sampleLinePoints(null, 20, 5)).to.eql([]);
+    });
+
+    it('returns first point for zero-length line', () => {
+      const result = overture._sampleLinePoints([[5, 5], [5, 5]], 20, 5);
+      expect(result.length).to.eql(1);
+      expect(result[0]).to.eql([5, 5]);
+    });
+
+    it('samples points along a line', () => {
+      // A line about 111km long (1 degree of latitude)
+      const coords = [[0, 0], [0, 1]];
+      const result = overture._sampleLinePoints(coords, 20, 5);
+      expect(result.length).to.be.greaterThan(1);
+      expect(result.length).to.be.at.most(20);
+      // First point should be the start
+      expect(result[0]).to.eql([0, 0]);
+    });
+
+    it('respects maxSamples limit', () => {
+      const coords = [[0, 0], [0, 1]];
+      const result = overture._sampleLinePoints(coords, 5, 1);
+      expect(result.length).to.be.at.most(5);
+    });
+  });
+
+
+  describe('#_distMeters', () => {
+    it('returns 0 for same point', () => {
+      expect(overture._distMeters([0, 0], [0, 0])).to.eql(0);
+    });
+
+    it('returns approximately correct distance for 1 degree latitude', () => {
+      // 1 degree of latitude ≈ 111,320 meters
+      const dist = overture._distMeters([0, 0], [0, 1]);
+      expect(dist).to.be.greaterThan(110000);
+      expect(dist).to.be.lessThan(112000);
+    });
+
+    it('accounts for longitude compression at higher latitudes', () => {
+      // At 60°N, 1 degree longitude ≈ half of what it is at equator
+      const distEquator = overture._distMeters([0, 0], [1, 0]);
+      const dist60 = overture._distMeters([0, 60], [1, 60]);
+      expect(dist60).to.be.lessThan(distEquator * 0.6);
+      expect(dist60).to.be.greaterThan(distEquator * 0.4);
+    });
+  });
+
+
+  describe('#_pointToSegmentDistance', () => {
+    it('returns 0 for point on segment', () => {
+      const dist = overture._pointToSegmentDistance([0.5, 0], [0, 0], [1, 0]);
+      expect(dist).to.be.lessThan(1); // should be ~0
+    });
+
+    it('returns distance to nearest endpoint when projection falls outside', () => {
+      // Point is beyond the end of the segment
+      const dist = overture._pointToSegmentDistance([2, 0], [0, 0], [1, 0]);
+      const endpointDist = overture._distMeters([2, 0], [1, 0]);
+      expect(Math.abs(dist - endpointDist)).to.be.lessThan(1);
+    });
+
+    it('returns perpendicular distance for projection within segment', () => {
+      // Point above midpoint of horizontal segment
+      const dist = overture._pointToSegmentDistance([0.5, 0.001], [0, 0], [1, 0]);
+      // Should be approximately the N-S distance of 0.001 degrees ≈ 111m
+      expect(dist).to.be.greaterThan(100);
+      expect(dist).to.be.lessThan(120);
+    });
+  });
+
+
+  describe('#_pointToLineDistance', () => {
+    it('returns minimum distance across all segments', () => {
+      // L-shaped polyline
+      const line = [[0, 0], [1, 0], [1, 1]];
+      // Point near the second segment
+      const dist = overture._pointToLineDistance([1.001, 0.5], line);
+      // Should be close to 0.001 degrees ≈ 111m longitude at equator, but ~55m at lat 0.5
+      expect(dist).to.be.greaterThan(50);
+      expect(dist).to.be.lessThan(150);
+    });
+  });
+
+
+  describe('#_conflateTransportation', () => {
+    // _conflateTransportation requires a fully wired context with editor, viewport, etc.
+    // These tests use minimal mocks to test the filtering and conversion logic.
+
+    function makeContextWithOSMHighways(osmWays) {
+      // Build a minimal mock graph and editor
+      const nodeEntities = {};
+      const wayEntities = {};
+      const allEntities = [];
+
+      for (const w of osmWays) {
+        const nodeIDs = [];
+        for (let i = 0; i < w.coords.length; i++) {
+          const nodeID = `n${Object.keys(nodeEntities).length}`;
+          nodeEntities[nodeID] = { id: nodeID, type: 'node', loc: w.coords[i] };
+          nodeIDs.push(nodeID);
+        }
+        const wayID = `w${Object.keys(wayEntities).length}`;
+        const way = {
+          id: wayID,
+          type: 'way',
+          tags: { highway: w.highway },
+          nodes: nodeIDs
+        };
+        wayEntities[wayID] = way;
+        allEntities.push(way);
+      }
+
+      const graph = {
+        entity: (id) => nodeEntities[id] || wayEntities[id]
+      };
+
+      return {
+        systems: {
+          editor: {
+            staging: { graph },
+            intersects: () => allEntities,
+            on: () => {}
+          }
+        },
+        services: {
+          vectortile: {
+            initAsync: () => Promise.resolve(),
+            startAsync: () => Promise.resolve()
+          }
+        },
+        viewport: {
+          transform: { zoom: 18 },
+          visibleExtent: () => ({
+            min: [-180, -90],
+            max: [180, 90],
+            rectangle: () => [-180, -90, 180, 90]
+          })
+        }
+      };
+    }
+
+    it('rejects OSM-sourced features', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f1',
+        geojson: {
+          id: 'f1',
+          geometry: { type: 'LineString', coordinates: [[0, 0], [1, 0]] },
+          properties: { '@geometry_source': 'OpenStreetMap', class: 'residential' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result).to.eql([]);
+    });
+
+    it('rejects non-TomTom features', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f1',
+        geojson: {
+          id: 'f1',
+          geometry: { type: 'LineString', coordinates: [[0, 0], [1, 0]] },
+          properties: { '@geometry_source': 'SomeOther', class: 'residential' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result).to.eql([]);
+    });
+
+    it('accepts TomTom features with no nearby OSM highways', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f1',
+        geojson: {
+          id: 'f1',
+          geometry: { type: 'LineString', coordinates: [[10, 10], [10.001, 10]] },
+          properties: { sources: [{ dataset: 'TomTom' }], class: 'residential' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result.length).to.be.greaterThan(0);
+    });
+
+    it('accepts TomTom features via sources JSON string', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f1b',
+        geojson: {
+          id: 'f1b',
+          geometry: { type: 'LineString', coordinates: [[10, 10], [10.001, 10]] },
+          properties: { sources: '[{"dataset":"TomTom"}]', class: 'residential' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result.length).to.be.greaterThan(0);
+    });
+
+    it('skips Point geometry', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f1',
+        geojson: {
+          id: 'f1',
+          geometry: { type: 'Point', coordinates: [0, 0] },
+          properties: { '@geometry_source': 'TomTom', class: 'residential' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result).to.eql([]);
+    });
+
+    it('deduplicates features by ID', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f1',
+        geojson: {
+          id: 'f1',
+          geometry: { type: 'LineString', coordinates: [[10, 10], [10.001, 10]] },
+          properties: { sources: [{ dataset: 'TomTom' }], class: 'residential' }
+        }
+      }];
+
+      // Process twice
+      svc._conflateTransportation(features, 'tomtom-roads');
+      // Second call: f1 is already in seen set, should not add again
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      // The ways from tree should contain only 1 way (from the first call)
+      const ways = result.filter(e => e.type === 'way');
+      expect(ways.length).to.eql(1);
+    });
+
+    it('returns empty for null/empty input', () => {
+      const ctx = makeContextWithOSMHighways([]);
+      const svc = new Rapid.OvertureService(ctx);
+      expect(svc._conflateTransportation(null, 'tomtom-roads')).to.eql([]);
+      expect(svc._conflateTransportation([], 'tomtom-roads')).to.eql([]);
+    });
+
+    it('rejects TomTom road overlapping a same-mode OSM highway', () => {
+      const ctx = makeContextWithOSMHighways([
+        { highway: 'residential', coords: [[10, 10], [10.001, 10]] }
+      ]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f2',
+        geojson: {
+          id: 'f2',
+          geometry: { type: 'LineString', coordinates: [[10, 10], [10.001, 10]] },
+          properties: { sources: [{ dataset: 'TomTom' }], class: 'residential' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result).to.eql([]);
+    });
+
+    it('does not reject a non-motorized road near a motorized OSM highway', () => {
+      const ctx = makeContextWithOSMHighways([
+        { highway: 'residential', coords: [[10, 10], [10.001, 10]] }
+      ]);
+      const svc = new Rapid.OvertureService(ctx);
+
+      const features = [{
+        id: 'f3',
+        geojson: {
+          id: 'f3',
+          geometry: { type: 'LineString', coordinates: [[10, 10], [10.001, 10]] },
+          properties: { sources: [{ dataset: 'TomTom' }], class: 'footway' }
+        }
+      }];
+
+      const result = svc._conflateTransportation(features, 'tomtom-roads');
+      expect(result.length).to.be.greaterThan(0);
+    });
+  });
+
 });

--- a/test/browser/services/OvertureService.test.js
+++ b/test/browser/services/OvertureService.test.js
@@ -302,6 +302,17 @@ describe('OvertureService', () => {
       };
       expect(overture._isConflatedWithOSM(lineCoords, [highway])).to.be.false;
     });
+
+    it('returns false when line diverges from OSM highway at an angle', () => {
+      // A road that shares a starting point with an OSM highway but diverges at ~45 degrees.
+      // The interior sample points should be far enough away to avoid conflation.
+      const lineCoords = [[10, 10], [10.0003, 10.0003], [10.0006, 10.0006]];
+      const highway = {
+        coords: [[10, 10], [10.0003, 10], [10.0006, 10]],
+        bbox: { minX: 9.999, minY: 9.999, maxX: 10.001, maxY: 10.001 }
+      };
+      expect(overture._isConflatedWithOSM(lineCoords, [highway])).to.be.false;
+    });
   });
 
 

--- a/test/browser/services/OvertureService.test.js
+++ b/test/browser/services/OvertureService.test.js
@@ -131,10 +131,6 @@ describe('OvertureService', () => {
 
 
   describe('#_getTransportationSource', () => {
-    it('returns source from @geometry_source property', () => {
-      expect(overture._getTransportationSource({ '@geometry_source': 'TomTom' })).to.eql('TomTom');
-    });
-
     it('returns source from sources array with dataset field', () => {
       expect(overture._getTransportationSource({
         sources: [{ dataset: 'TomTom', license: 'ODbL-1.0' }]
@@ -158,13 +154,6 @@ describe('OvertureService', () => {
 
     it('returns null for malformed JSON string', () => {
       expect(overture._getTransportationSource({ sources: 'not-json' })).to.be.null;
-    });
-
-    it('prefers @geometry_source over sources array', () => {
-      expect(overture._getTransportationSource({
-        '@geometry_source': 'Google',
-        sources: [{ dataset: 'TomTom' }]
-      })).to.eql('Google');
     });
   });
 
@@ -285,60 +274,33 @@ describe('OvertureService', () => {
   });
 
 
-  describe('#_distMeters', () => {
-    it('returns 0 for same point', () => {
-      expect(overture._distMeters([0, 0], [0, 0])).to.eql(0);
+  describe('#_isConflatedWithOSM', () => {
+    it('returns false for null/short coords', () => {
+      expect(overture._isConflatedWithOSM(null, [])).to.be.false;
+      expect(overture._isConflatedWithOSM([[0, 0]], [])).to.be.false;
     });
 
-    it('returns approximately correct distance for 1 degree latitude', () => {
-      // 1 degree of latitude ≈ 111,320 meters
-      const dist = overture._distMeters([0, 0], [0, 1]);
-      expect(dist).to.be.greaterThan(110000);
-      expect(dist).to.be.lessThan(112000);
+    it('returns false when no highways to compare against', () => {
+      const coords = [[10, 10], [10.001, 10]];
+      expect(overture._isConflatedWithOSM(coords, [])).to.be.false;
     });
 
-    it('accounts for longitude compression at higher latitudes', () => {
-      // At 60°N, 1 degree longitude ≈ half of what it is at equator
-      const distEquator = overture._distMeters([0, 0], [1, 0]);
-      const dist60 = overture._distMeters([0, 60], [1, 60]);
-      expect(dist60).to.be.lessThan(distEquator * 0.6);
-      expect(dist60).to.be.greaterThan(distEquator * 0.4);
-    });
-  });
-
-
-  describe('#_pointToSegmentDistance', () => {
-    it('returns 0 for point on segment', () => {
-      const dist = overture._pointToSegmentDistance([0.5, 0], [0, 0], [1, 0]);
-      expect(dist).to.be.lessThan(1); // should be ~0
+    it('returns true when line overlaps an OSM highway', () => {
+      const lineCoords = [[10, 10], [10.001, 10]];
+      const highway = {
+        coords: [[10, 10], [10.001, 10]],
+        bbox: { minX: 9.999, minY: 9.999, maxX: 10.002, maxY: 10.001 }
+      };
+      expect(overture._isConflatedWithOSM(lineCoords, [highway])).to.be.true;
     });
 
-    it('returns distance to nearest endpoint when projection falls outside', () => {
-      // Point is beyond the end of the segment
-      const dist = overture._pointToSegmentDistance([2, 0], [0, 0], [1, 0]);
-      const endpointDist = overture._distMeters([2, 0], [1, 0]);
-      expect(Math.abs(dist - endpointDist)).to.be.lessThan(1);
-    });
-
-    it('returns perpendicular distance for projection within segment', () => {
-      // Point above midpoint of horizontal segment
-      const dist = overture._pointToSegmentDistance([0.5, 0.001], [0, 0], [1, 0]);
-      // Should be approximately the N-S distance of 0.001 degrees ≈ 111m
-      expect(dist).to.be.greaterThan(100);
-      expect(dist).to.be.lessThan(120);
-    });
-  });
-
-
-  describe('#_pointToLineDistance', () => {
-    it('returns minimum distance across all segments', () => {
-      // L-shaped polyline
-      const line = [[0, 0], [1, 0], [1, 1]];
-      // Point near the second segment
-      const dist = overture._pointToLineDistance([1.001, 0.5], line);
-      // Should be close to 0.001 degrees ≈ 111m longitude at equator, but ~55m at lat 0.5
-      expect(dist).to.be.greaterThan(50);
-      expect(dist).to.be.lessThan(150);
+    it('returns false when line is far from OSM highways', () => {
+      const lineCoords = [[20, 20], [20.001, 20]];
+      const highway = {
+        coords: [[10, 10], [10.001, 10]],
+        bbox: { minX: 9.999, minY: 9.999, maxX: 10.002, maxY: 10.001 }
+      };
+      expect(overture._isConflatedWithOSM(lineCoords, [highway])).to.be.false;
     });
   });
 
@@ -409,7 +371,7 @@ describe('OvertureService', () => {
         geojson: {
           id: 'f1',
           geometry: { type: 'LineString', coordinates: [[0, 0], [1, 0]] },
-          properties: { '@geometry_source': 'OpenStreetMap', class: 'residential' }
+          properties: { sources: [{ dataset: 'OpenStreetMap' }], class: 'residential' }
         }
       }];
 
@@ -426,7 +388,7 @@ describe('OvertureService', () => {
         geojson: {
           id: 'f1',
           geometry: { type: 'LineString', coordinates: [[0, 0], [1, 0]] },
-          properties: { '@geometry_source': 'SomeOther', class: 'residential' }
+          properties: { sources: [{ dataset: 'SomeOther' }], class: 'residential' }
         }
       }];
 
@@ -477,7 +439,7 @@ describe('OvertureService', () => {
         geojson: {
           id: 'f1',
           geometry: { type: 'Point', coordinates: [0, 0] },
-          properties: { '@geometry_source': 'TomTom', class: 'residential' }
+          properties: { sources: [{ dataset: 'TomTom' }], class: 'residential' }
         }
       }];
 

--- a/test/unit/actions/rapid_accept_feature.test.js
+++ b/test/unit/actions/rapid_accept_feature.test.js
@@ -38,7 +38,6 @@ describe('actionRapidAcceptFeature', () => {
         const node2 = Rapid.osmNode({ id: 'n2', loc: [1, 1] });
         const extGraph = new Rapid.Graph([node, way, node1, node2]);
         const graph = Rapid.actionRapidAcceptFeature(node.id, extGraph)(new Rapid.Graph([way, node1, node2]));
-        // Replace with your actual assertions
         assert.ok(graph.hasEntity(node.id));
         assert.ok(graph.hasEntity(way.id));
     });
@@ -49,7 +48,6 @@ describe('actionRapidAcceptFeature', () => {
         const node2 = Rapid.osmNode({ id: 'b', loc: [1, 1], tags: { dupe: 'a' } });
         const way = Rapid.osmWay({ id: 'w', nodes: [node1.id, node2.id] });
         const graph = Rapid.actionRapidAcceptFeature(way.id, new Rapid.Graph([node1, node2, way]))(new Rapid.Graph());
-        // Replace with your actual assertions
         assert.ok(graph.hasEntity(way.id));
     });
 
@@ -60,7 +58,6 @@ describe('actionRapidAcceptFeature', () => {
         const relation1 = Rapid.osmRelation({ id: 'r1', members: [{ id: way.id }] });
         const relation2 = Rapid.osmRelation({ id: 'r2', members: [{ id: relation1.id }] });
         const graph = Rapid.actionRapidAcceptFeature(relation2.id, new Rapid.Graph([node, way, relation1, relation2]))(new Rapid.Graph());
-        // Replace with your actual assertions
         assert.ok(graph.hasEntity(relation2.id));
     });
 
@@ -79,5 +76,194 @@ describe('actionRapidAcceptFeature', () => {
         const node = Rapid.osmNode({ id: 'a', loc: [0, 0] });
         const graph = Rapid.actionRapidAcceptFeature(node.id, new Rapid.Graph([node]))(new Rapid.Graph());
         assert.ok(graph.hasEntity(node.id));
+    });
+
+
+    describe('auto-connect endpoints', () => {
+        // Helper: build an OSM graph containing the given entities, and a Tree indexing them
+        function buildOsmScene(osmEntities) {
+            const osmGraph = new Rapid.Graph(osmEntities);
+            const tree = new Rapid.Tree(osmGraph);
+            tree.rebase(osmEntities);
+            return { osmGraph, tree };
+        }
+
+        // Shared fixture: east-west residential highway [0,0] -> [1,0]
+        function makeHighway(tags) {
+            const hwyN1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+            const hwyN2 = Rapid.osmNode({ id: 'n2', loc: [1, 0] });
+            const highway = Rapid.osmWay({ id: 'w1', nodes: ['n1', 'n2'],
+                tags: Object.assign({ highway: 'residential' }, tags) });
+            return [hwyN1, hwyN2, highway];
+        }
+
+        // Helper: build a TomTom external graph with a 2-node way
+        // First node at [0.5, 0.5], second node at the given loc
+        function makeExtGraph(endpointLoc, wayTags) {
+            const extN1 = Rapid.osmNode({ id: 'e1', loc: [0.5, 0.5] });
+            const extN2 = Rapid.osmNode({ id: 'e2', loc: endpointLoc });
+            const extWay = Rapid.osmWay({ id: 'ew1', nodes: ['e1', 'e2'],
+                tags: Object.assign({ highway: 'tertiary' }, wayTags) });
+            return new Rapid.Graph([extN1, extN2, extWay]);
+        }
+
+        // Helper: build ext graph where nodes have custom tags
+        function makeExtGraphWithNodeTags(endpointLoc, nodeTags, wayTags) {
+            const extN1 = Rapid.osmNode({ id: 'e1', loc: [0.5, 0.5] });
+            const extN2 = Rapid.osmNode({ id: 'e2', loc: endpointLoc, tags: nodeTags });
+            const extWay = Rapid.osmWay({ id: 'ew1', nodes: ['e1', 'e2'],
+                tags: Object.assign({ highway: 'tertiary' }, wayTags) });
+            return new Rapid.Graph([extN1, extN2, extWay]);
+        }
+
+
+        it('auto-connects endpoint to nearby highway segment', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway());
+            const extGraph = makeExtGraph([0.5, 0.00003]);  // ~3m from highway
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const acceptedWay = result.entity('ew1');
+            const endNode = result.entity(acceptedWay.nodes[acceptedWay.nodes.length - 1]);
+            assert.ok(Math.abs(endNode.loc[1]) < 0.0001, 'endpoint should be snapped to highway latitude');
+
+            const updatedHighway = result.entity('w1');
+            assert.ok(updatedHighway.nodes.length === 3, 'highway should have 3 nodes after splice');
+            assert.ok(updatedHighway.nodes.includes(endNode.id), 'highway should include the snapped node');
+        });
+
+
+        it('merges endpoint with nearby existing node', () => {
+            const hwyN1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+            const hwyN2 = Rapid.osmNode({ id: 'n2', loc: [0.5, 0] });
+            const hwyN3 = Rapid.osmNode({ id: 'n3', loc: [1, 0] });
+            const highway = Rapid.osmWay({ id: 'w1', nodes: ['n1', 'n2', 'n3'], tags: { highway: 'residential' } });
+            const { osmGraph, tree } = buildOsmScene([hwyN1, hwyN2, hwyN3, highway]);
+
+            const extGraph = makeExtGraph([0.5, 0.000005]);  // ~0.5m from n2
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const acceptedWay = result.entity('ew1');
+            assert.equal(acceptedWay.nodes[acceptedWay.nodes.length - 1], 'n2',
+                'endpoint should be merged with existing highway node');
+            assert.ok(!result.hasEntity('e2'), 'orphaned original node should be removed');
+        });
+
+
+        it('merges instead of creating duplicate when projection lands on existing node', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway());
+
+            // Endpoint near n1 but off-axis — projection clamps to n1's location
+            const extN1 = Rapid.osmNode({ id: 'e1', loc: [-0.5, 0.5] });
+            const extN2 = Rapid.osmNode({ id: 'e2', loc: [-0.00001, 0.00003] });
+            const extWay = Rapid.osmWay({ id: 'ew1', nodes: ['e1', 'e2'], tags: { highway: 'tertiary' } });
+            const extGraph = new Rapid.Graph([extN1, extN2, extWay]);
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const acceptedWay = result.entity('ew1');
+            assert.equal(acceptedWay.nodes[acceptedWay.nodes.length - 1], 'n1',
+                'endpoint should be merged with nearby highway node, not duplicated');
+            const updatedHighway = result.entity('w1');
+            assert.equal(updatedHighway.nodes.length, 2, 'highway should still have 2 nodes (no duplicate)');
+        });
+
+
+        it('does not connect when distance exceeds threshold', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway());
+            const extGraph = makeExtGraph([0.5, 0.0002]);  // ~22m away
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const updatedHighway = result.entity('w1');
+            assert.equal(updatedHighway.nodes.length, 2, 'highway should still have 2 nodes');
+            const acceptedWay = result.entity('ew1');
+            const endNode = result.entity(acceptedWay.nodes[acceptedWay.nodes.length - 1]);
+            assert.ok(Math.abs(endNode.loc[1] - 0.0002) < 0.0001, 'endpoint should not be moved');
+        });
+
+
+        it('does not connect across different layers', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway({ bridge: 'yes', layer: '1' }));
+            const extGraph = makeExtGraph([0.5, 0.00003]);  // ~3m from bridge
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const updatedHighway = result.entity('w1');
+            assert.equal(updatedHighway.nodes.length, 2, 'highway should still have 2 nodes');
+        });
+
+
+        it('preserves existing conn tag behavior', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway());
+            const extGraph = makeExtGraphWithNodeTags(
+                [0.5, 0.00003], { conn: 'w1,n1,n2' }
+            );
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const acceptedWay = result.entity('ew1');
+            assert.ok(acceptedWay, 'way should be accepted');
+            const endNode = result.entity(acceptedWay.nodes[acceptedWay.nodes.length - 1]);
+            assert.ok(!endNode.tags.conn, 'conn tag should be removed');
+        });
+
+
+        it('skips auto-connect when tree is null', () => {
+            const osmGraph = new Rapid.Graph(makeHighway());
+            const extGraph = makeExtGraph([0.5, 0.00003]);
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph)(osmGraph);
+
+            assert.ok(result.hasEntity('ew1'), 'way should be accepted');
+            const updatedHighway = result.entity('w1');
+            assert.equal(updatedHighway.nodes.length, 2, 'highway should remain unchanged');
+        });
+
+
+        it('connects both endpoints independently', () => {
+            const hwyN1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+            const hwyN2 = Rapid.osmNode({ id: 'n2', loc: [1, 0] });
+            const highway1 = Rapid.osmWay({ id: 'w1', nodes: ['n1', 'n2'], tags: { highway: 'residential' } });
+            const hwyN3 = Rapid.osmNode({ id: 'n3', loc: [0, 1] });
+            const hwyN4 = Rapid.osmNode({ id: 'n4', loc: [1, 1] });
+            const highway2 = Rapid.osmWay({ id: 'w2', nodes: ['n3', 'n4'], tags: { highway: 'residential' } });
+            const { osmGraph, tree } = buildOsmScene([hwyN1, hwyN2, highway1, hwyN3, hwyN4, highway2]);
+
+            const extN1 = Rapid.osmNode({ id: 'e1', loc: [0.5, 0.00003] });   // ~3m from highway1
+            const extN2 = Rapid.osmNode({ id: 'e2', loc: [0.5, 0.99997] });   // ~3m from highway2
+            const extWay = Rapid.osmWay({ id: 'ew1', nodes: ['e1', 'e2'], tags: { highway: 'tertiary' } });
+            const extGraph = new Rapid.Graph([extN1, extN2, extWay]);
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            assert.equal(result.entity('w1').nodes.length, 3, 'highway1 should have 3 nodes after splice');
+            assert.equal(result.entity('w2').nodes.length, 3, 'highway2 should have 3 nodes after splice');
+        });
+
+
+        it('inherits highway tag from connected way when accepted way has highway=road', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway());
+            const extGraph = makeExtGraph([0.5, 0.00003], { highway: 'road' });
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const acceptedWay = result.entity('ew1');
+            assert.equal(acceptedWay.tags.highway, 'residential',
+                'highway tag should be inherited from connected way');
+        });
+
+
+        it('does not inherit highway tag when accepted way has a specific classification', () => {
+            const { osmGraph, tree } = buildOsmScene(makeHighway());
+            const extGraph = makeExtGraph([0.5, 0.00003]);  // default: highway=tertiary
+
+            const result = Rapid.actionRapidAcceptFeature('ew1', extGraph, tree)(osmGraph);
+
+            const acceptedWay = result.entity('ew1');
+            assert.equal(acceptedWay.tags.highway, 'tertiary',
+                'highway tag should not be overwritten when it is already specific');
+        });
     });
 });


### PR DESCRIPTION
First step to enabling non-OSM sourced Overture transportation data from TomTom to be added into OSM. There are some theoretical edge cases here involving midpoint intersections but Rapid does a good job of detecting issues and helping resolve.

Tested:
* Connecting two roads together
* Multiple TT roads connected in a chain
* Adding FB roads together with TT roads
* Submission (test changeset: https://osmcha.org/changesets/178739218)

From `/#map=17.26/38.62021/27.47057&background=Bing&datasets=ml-buildings-overture,tomtom-roads`

https://github.com/user-attachments/assets/2f340e76-1da1-4e03-b3aa-929a9e21c8f2

