### PR TITLE
Fix unsanitized tag values

### DIFF
--- a/modules/ui/combobox.js
+++ b/modules/ui/combobox.js
@@ -1,7 +1,7 @@
 import { dispatch as d3_dispatch } from 'd3-dispatch';
 import { select as d3_select } from 'd3-selection';
 
-import { utilGetSetValue, utilRebind, utilTriggerEvent } from '../util/index.js';
+import { utilGetSetValue, utilRebind, utilSanitizeHTML, utilTriggerEvent } from '../util/index.js';
 
 
 // This code assumes that the combobox values will not have duplicate entries.
@@ -390,7 +390,7 @@ export function uiCombobox(context, klass) {
                     if (typeof d.display === 'function') {  // display function
                         selection.call(d.display);
                     } else if (d.display) {                 // display html value
-                        selection.html(d.display);
+                        selection.html(utilSanitizeHTML(d.display));
                     } else {                                // text value
                         selection.text(d.value);
                     }

--- a/modules/ui/fields/check.js
+++ b/modules/ui/fields/check.js
@@ -34,14 +34,14 @@ export function uiFieldCheck(context, uifield) {
   if (Array.isArray(options)) {
     for (const v of options) {
       values.push(v === 'undefined' ? undefined : v);
-      texts.push(uifield.tHtml(`options.${v}`, { 'default': v }));
+      texts.push(uifield.t(`options.${v}`, { 'default': v }));
     }
   } else {
     values = [undefined, 'yes'];
-    texts = [l10n.tHtml('inspector.unknown'), l10n.tHtml('inspector.check.yes')];
+    texts = [l10n.t('inspector.unknown'), l10n.t('inspector.check.yes')];
     if (uifield.type !== 'defaultCheck') {
       values.push('no');
-      texts.push(l10n.tHtml('inspector.check.no'));
+      texts.push(l10n.t('inspector.check.no'));
     }
   }
 
@@ -58,7 +58,7 @@ export function uiFieldCheck(context, uifield) {
       for (let key in entity.tags) {
         if (key in osmOneWayTags && (entity.tags[key] in osmOneWayTags[key])) {
           _impliedYes = true;
-          texts[0] = l10n.tHtml('_tagging.presets.fields.oneway_yes.options.undefined');
+          texts[0] = l10n.t('_tagging.presets.fields.oneway_yes.options.undefined');
           break;
         }
       }
@@ -83,7 +83,7 @@ export function uiFieldCheck(context, uifield) {
     const icon = pseudoDirection ? '#rapid-icon-forward' : '#rapid-icon-backward';
 
     selection.selectAll('.reverser-span')
-      .html(l10n.tHtml('inspector.check.reverser'))
+      .text(l10n.t('inspector.check.reverser'))
       .call(uiIcon(icon, 'inline'));
 
     return selection;
@@ -108,7 +108,7 @@ export function uiFieldCheck(context, uifield) {
 
     enter
       .append('span')
-      .html(texts[0])
+      .text(texts[0])
       .attr('class', 'value');
 
     if (uifield.type === 'onewayCheck') {
@@ -213,7 +213,7 @@ export function uiFieldCheck(context, uifield) {
       .property('checked', isChecked(_value));
 
     text
-      .html(isMixed ? l10n.tHtml('inspector.multiple_values') : textFor(_value))
+      .text(isMixed ? l10n.t('inspector.multiple_values') : textFor(_value))
       .classed('mixed', isMixed);
 
     label

--- a/modules/ui/fields/radio.js
+++ b/modules/ui/fields/radio.js
@@ -64,7 +64,7 @@ export function uiFieldRadio(context, uifield) {
 
         enter
             .append('span')
-            .html(function(d) { return uifield.tHtml(`options.${d}`, { 'default': d }); });
+            .text(function(d) { return uifield.t(`options.${d}`, { 'default': d }); });
 
         labels = labels
             .merge(enter);
@@ -297,9 +297,9 @@ export function uiFieldRadio(context, uifield) {
         var selection = radios.filter(function() { return this.checked; });
 
         if (selection.empty()) {
-            placeholder.html(l10n.tHtml('inspector.none'));
+            placeholder.text(l10n.t('inspector.none'));
         } else {
-            placeholder.html(selection.attr('value'));
+            placeholder.text(selection.attr('value'));
             _oldType[selection.datum()] = tags[selection.datum()];
         }
 

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -360,7 +360,7 @@ export function uiPresetList(context) {
         .attr('class', 'namepart')
         .call(uiIcon((isRTL ? '#rapid-icon-backward' : '#rapid-icon-forward'), 'inline'))
         .append('span')
-        .html(() => preset.nameLabel() + '&hellip;');
+        .text(() => preset.name() + '\u2026');
 
       this.box = selection
         .append('div')
@@ -472,8 +472,8 @@ export function uiPresetList(context) {
         .attr('class', 'label-inner');
 
       const nameparts = [
-        preset.nameLabel(),
-        preset.subtitleLabel()
+        preset.name(),
+        preset.subtitle()
       ].filter(Boolean);
 
       labelEnter.selectAll('.namepart')
@@ -481,7 +481,7 @@ export function uiPresetList(context) {
         .enter()
         .append('div')
         .attr('class', 'namepart')
-        .html(d => d);
+        .text(d => d);
 
       wrapEnter.call(this.reference.button);
       selection.call(this.reference.body);

--- a/modules/ui/sections/feature_type.js
+++ b/modules/ui/sections/feature_type.js
@@ -91,8 +91,8 @@ export function uiSectionFeatureType(context) {
       );
 
     let names = _presets.length === 1 ? [
-      _presets[0].nameLabel(),
-      _presets[0].subtitleLabel()
+      _presets[0].name(),
+      _presets[0].subtitle()
     ].filter(Boolean) : [l10n.t('inspector.multiple_types')];
 
     let label = selection.select('.label-inner');
@@ -106,7 +106,7 @@ export function uiSectionFeatureType(context) {
       .enter()
       .append('div')
       .attr('class', 'namepart')
-      .html(d => d);
+      .text(d => d);
   }
 
   section.entityIDs = function(val) {

--- a/modules/ui/sections/raw_member_editor.js
+++ b/modules/ui/sections/raw_member_editor.js
@@ -187,7 +187,7 @@ export function uiSectionRawMemberEditor(context) {
           labelLink
             .append('span')
             .attr('class', 'member-entity-type')
-            .html(d => {
+            .text(d => {
               const matched = presets.match(d.member, editor.staging.graph);
               return (matched && matched.name()) || l10n.displayType(d.member.id);
             });

--- a/modules/ui/sections/raw_membership_editor.js
+++ b/modules/ui/sections/raw_membership_editor.js
@@ -365,7 +365,7 @@ export function uiSectionRawMembershipEditor(context) {
         labelLink
             .append('span')
             .attr('class', 'member-entity-type')
-            .html(function(d) {
+            .text(function(d) {
                 const matched = presets.match(d.relation, editor.staging.graph);
                 return (matched && matched.name()) || l10n.t('inspector.relation');
             });

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -1,6 +1,7 @@
 import { select as d3_select } from 'd3-selection';
 
 import { uiIcon } from './icon.js';
+import { utilSanitizeHTML } from '../util/index.js';
 
 
 // Pass `what` object of the form:
@@ -62,7 +63,7 @@ export function uiTagReference(context, what) {
 
     let docsHtml;
     if (docs.description) {
-      docsHtml = l10n.htmlForLocalizedText(docs.description, docs.descriptionLocaleCode);
+      docsHtml = utilSanitizeHTML(l10n.htmlForLocalizedText(docs.description, docs.descriptionLocaleCode));
     } else {
       docsHtml = l10n.tHtml('inspector.no_documentation_key');
     }

--- a/modules/util/sanitize.js
+++ b/modules/util/sanitize.js
@@ -19,7 +19,7 @@ export function utilSanitizeHTML(dirty) {
       'thead', 'tr', 'u', 'ul'
     ],
     ALLOWED_ATTR: [
-      'class', 'href', 'id', 'name', 'rel', 'src', 'target', 'title', 'alt',
+      'class', 'href', 'id', 'lang', 'name', 'rel', 'src', 'target', 'title', 'alt',
       'value', 'data-osm-id', 'data-osm-type'
     ],
     ALLOW_DATA_ATTR: false,

--- a/test/browser/util/sanitize.js
+++ b/test/browser/util/sanitize.js
@@ -1,0 +1,45 @@
+describe('utilSanitizeHTML', () => {
+  const utilSanitizeHTML = Rapid.utilSanitizeHTML;
+
+  it('returns empty string for falsy input', () => {
+    expect(utilSanitizeHTML('')).to.eql('');
+    expect(utilSanitizeHTML(null)).to.eql('');
+    expect(utilSanitizeHTML(undefined)).to.eql('');
+  });
+
+  it('strips script tags', () => {
+    expect(utilSanitizeHTML('<script>alert("xss")</script>')).to.eql('');
+  });
+
+  it('strips iframe tags', () => {
+    expect(utilSanitizeHTML('<iframe src="evil.com"></iframe>')).to.eql('');
+  });
+
+  it('strips form and input tags', () => {
+    expect(utilSanitizeHTML('<form><input type="text"></form>')).to.eql('');
+  });
+
+  it('strips event handler attributes', () => {
+    expect(utilSanitizeHTML('<img src="x" onerror="alert(1)">')).to.eql('<img src="x">');
+  });
+
+  it('strips style attributes', () => {
+    expect(utilSanitizeHTML('<span style="color:red">text</span>')).to.eql('<span>text</span>');
+  });
+
+  it('allows safe inline tags', () => {
+    expect(utilSanitizeHTML('<b>bold</b> <em>em</em> <mark>mark</mark>')).to.eql('<b>bold</b> <em>em</em> <mark>mark</mark>');
+  });
+
+  it('preserves lang attribute', () => {
+    expect(utilSanitizeHTML('<span lang="de">Straße</span>')).to.eql('<span lang="de">Straße</span>');
+  });
+
+  it('preserves class and href attributes', () => {
+    expect(utilSanitizeHTML('<a href="https://example.com" class="link">click</a>')).to.eql('<a href="https://example.com" class="link">click</a>');
+  });
+
+  it('preserves data-osm-id and data-osm-type attributes', () => {
+    expect(utilSanitizeHTML('<span data-osm-id="123" data-osm-type="node">test</span>')).to.eql('<span data-osm-id="123" data-osm-type="node">test</span>');
+  });
+});


### PR DESCRIPTION
Three independent code paths in the entity editor rendered OSM tag values directly into the DOM via .html() (innerHTML) without sanitization.

Fixes:
- check.js: switch entirely from tHtml/html to t/text
- combobox.js: sanitize display HTML with DOMPurify
- radio.js: switch from tHtml/html to t/text

Additional hardening:
- tag_reference.js: sanitize wiki descriptions from OSM wikibase
- feature_type.js, preset_list.js: use name()/text() not nameLabel()/html()
- raw_member_editor.js, raw_membership_editor.js: html() to text()
- sanitize.js: add 'lang' to DOMPurify ALLOWED_ATTR
