### PR TITLE
Add snap preview for point placement mode

### DIFF
--- a/modules/behaviors/DrawBehavior.js
+++ b/modules/behaviors/DrawBehavior.js
@@ -1,372 +1,263 @@
 import { vecLength } from '@rapid-sdk/math';
 
 import { AbstractBehavior } from './AbstractBehavior.js';
-// import { geoChooseEdge } from '../geo/index.js';
 import { utilDetect } from '../util/detect.js';
+import { SnapSystem } from '../core/SnapSystem.js';
 
 const NEAR_TOLERANCE = 4;
 const FAR_TOLERANCE = 12;
 
 
 /**
- * `DrawBehavior` listens to pointer and click events and translates those into drawing events
+ * `DrawBehavior` listens to pointer and click events and translates those into drawing events.
  *
  * Properties available:
- *   `enabled`    `true` if the event handlers are enabled, `false` if not.
- *   `lastDown`   `eventData` Object for the most recent down event
- *   `lastMove`   `eventData` Object for the most recent move event
- *   `lastSpace`  `eventData` Object for the most recent move event used to trigger a spacebar click
- *   `lastClick`  `eventData` Object for the most recent click event
+ *   `enabled`      `true` if the event handlers are enabled, `false` if not.
+ *   `lastDown`     `eventData` Object for the most recent down event
+ *   `lastMove`     `eventData` Object for the most recent move event
+ *   `lastSpace`    `eventData` Object for the most recent spacebar-click move event
+ *   `lastClick`    `eventData` Object for the most recent click event
  *
  * Events available:
- *   `down`      Fires on initial pointerdown, receives `eventData` Object
- *   `move`      Fires on _any_ pointermove (or change of modifier key), receives `eventData` Object
- *   `cancel`    Fires if the user presses Delete or Backspace
- *   `click`     Fires on a successful click (or spacebar), receives `eventData` for the event that triggered the click
- *   `finish`    Fires if user presses return, enter, or escape
+ *   `move`    Fires on pointermove. Receives eventData with eventData.snapResult attached.
+ *             All original eventData fields are unmodified.
+ *             eventData.snapResult is the snap result from SnapSystem, or null if snap disabled.
+ *   `click`   Fires on a successful click. Same shape as move.
+ *   `down`    Fires on pointerdown. Receives original eventData.
+ *   `cancel`  Fires on Delete/Backspace.
+ *   `finish`  Fires on Enter/Escape.
  */
 export class DrawBehavior extends AbstractBehavior {
 
-  /**
-   * @constructor
-   * @param  `context`  Global shared application context
-   */
-  constructor(context) {
-    super(context);
-    this.id = 'draw';
+	constructor(context) {
+		super(context);
+		this.id = 'draw';
 
-    this._spaceClickDisabled = false;
+		this._spaceClickDisabled = false;
 
-    this.lastDown = null;
-    this.lastMove = null;
-    this.lastSpace = null;
-    this.lastClick = null;
+		this.lastDown = null;
+		this.lastMove = null;
+		this.lastSpace = null;
+		this.lastClick = null;
 
-    // Make sure the event handlers have `this` bound correctly
-    this._doClick = this._doClick.bind(this);
-    this._doMove = this._doMove.bind(this);
-    this._keydown = this._keydown.bind(this);
-    this._keyup = this._keyup.bind(this);
-    this._pointercancel = this._pointercancel.bind(this);
-    this._pointerdown = this._pointerdown.bind(this);
-    this._pointermove = this._pointermove.bind(this);
-    this._pointerup = this._pointerup.bind(this);
-  }
+		this._doClick = this._doClick.bind(this);
+		this._doMove = this._doMove.bind(this);
+		this._keydown = this._keydown.bind(this);
+		this._keyup = this._keyup.bind(this);
+		this._pointercancel = this._pointercancel.bind(this);
+		this._pointerdown = this._pointerdown.bind(this);
+		this._pointermove = this._pointermove.bind(this);
+		this._pointerup = this._pointerup.bind(this);
+	}
 
 
-  /**
-   * enable
-   * Bind event handlers
-   */
-  enable() {
-    if (this._enabled) return;
+	enable() {
+		if (this._enabled) {
+			return;
+		}
 
-    this._enabled = true;
-    this.lastDown = null;
-    this.lastMove = null;
-    this.lastSpace = null;
-    this.lastClick = null;
+		this._enabled = true;
+		this.lastDown = null;
+		this.lastMove = null;
+		this.lastSpace = null;
+		this.lastClick = null;
+		this._spaceClickDisabled = false;
 
-    this._spaceClickDisabled = false;
-
-    const eventManager = this.context.systems.gfx.events;
-    eventManager.on('keydown', this._keydown);
-    eventManager.on('keyup', this._keyup);
-    eventManager.on('modifierchange', this._doMove);
-    eventManager.on('pointerover', this._doMove);
-    eventManager.on('pointerout', this._doMove);
-    eventManager.on('pointerdown', this._pointerdown);
-    eventManager.on('pointermove', this._pointermove);
-    eventManager.on('pointerup', this._pointerup);
-    eventManager.on('pointercancel', this._pointercancel);
-  }
+		const eventManager = this.context.systems.gfx.events;
+		eventManager.on('keydown', this._keydown);
+		eventManager.on('keyup', this._keyup);
+		eventManager.on('modifierchange', this._doMove);
+		eventManager.on('pointerover', this._doMove);
+		eventManager.on('pointerout', this._doMove);
+		eventManager.on('pointerdown', this._pointerdown);
+		eventManager.on('pointermove', this._pointermove);
+		eventManager.on('pointerup', this._pointerup);
+		eventManager.on('pointercancel', this._pointercancel);
+	}
 
 
-  /**
-   * disable
-   * Unbind event handlers
-   */
-  disable() {
-    if (!this._enabled) return;
+	disable() {
+		if (!this._enabled) {
+			return;
+		}
 
-    this._enabled = false;
-    this.lastDown = null;
-    this.lastMove = null;
-    this.lastSpace = null;
-    this.lastClick = null;
+		this._enabled = false;
+		this.lastDown = null;
+		this.lastMove = null;
+		this.lastSpace = null;
+		this.lastClick = null;
+		this._spaceClickDisabled = false;
 
-    this._spaceClickDisabled = false;
-
-    const eventManager = this.context.systems.gfx.events;
-    eventManager.off('keydown', this._keydown);
-    eventManager.off('keyup', this._keyup);
-    eventManager.off('modifierchange', this._doMove);
-    eventManager.off('pointerover', this._doMove);
-    eventManager.off('pointerout', this._doMove);
-    eventManager.off('pointerdown', this._pointerdown);
-    eventManager.off('pointermove', this._pointermove);
-    eventManager.off('pointerup', this._pointerup);
-    eventManager.off('pointercancel', this._pointercancel);
-  }
+		const eventManager = this.context.systems.gfx.events;
+		eventManager.off('keydown', this._keydown);
+		eventManager.off('keyup', this._keyup);
+		eventManager.off('modifierchange', this._doMove);
+		eventManager.off('pointerover', this._doMove);
+		eventManager.off('pointerout', this._doMove);
+		eventManager.off('pointerdown', this._pointerdown);
+		eventManager.off('pointermove', this._pointermove);
+		eventManager.off('pointerup', this._pointerup);
+		eventManager.off('pointercancel', this._pointercancel);
+	}
 
 
-  /**
-   * _keydown
-   * Handler for keydown events on the window.
-   * @param  `e`  A DOM KeyboardEvent
-   */
-  _keydown(e) {
-    if (['Enter', 'Escape', 'Esc'].includes(e.key)) {
-      e.preventDefault();
-      this.emit('finish');
-
-    } else if (['Backspace', 'Delete', 'Del'].includes(e.key)) {
-      e.preventDefault();
-      this.emit('cancel');
-
-    // After spacebar click, user must move pointer or lift spacebar to allow another spacebar click
-    } else if (!this._spaceClickDisabled && [' ', 'Spacebar'].includes(e.key)) {
-      e.preventDefault();
-      e.stopPropagation();
-      this._spacebar();
-    }
-  }
+	_keydown(e) {
+		if (['Enter', 'Escape', 'Esc'].includes(e.key)) {
+			e.preventDefault();
+			this.emit('finish');
+		}
+		else if (['Backspace', 'Delete', 'Del'].includes(e.key)) {
+			e.preventDefault();
+			this.emit('cancel');
+		}
+		else if (!this._spaceClickDisabled && [' ', 'Spacebar'].includes(e.key)) {
+			e.preventDefault();
+			e.stopPropagation();
+			this._spacebar();
+		}
+	}
 
 
-  /**
-   * _keyup
-   * Handler for keyup events on the window.
-   * @param  `e`  A DOM KeyboardEvent
-   */
-  _keyup(e) {
-    // After spacebar click, user must move pointer or lift spacebar to allow another spacebar click
-    if (this._spaceClickDisabled && [' ', 'Spacebar'].includes(e.key)) {
-      e.preventDefault();
-      e.stopPropagation();
-      this._spaceClickDisabled = false;
-    }
-  }
+	_keyup(e) {
+		if (this._spaceClickDisabled && [' ', 'Spacebar'].includes(e.key)) {
+			e.preventDefault();
+			e.stopPropagation();
+			this._spaceClickDisabled = false;
+		}
+	}
 
 
-  /**
-   * _pointerdown
-   * Handler for pointerdown events.  Note that you can get multiples of these
-   * if the user taps with multiple fingers. We lock in the first one in `lastDown`.
-   * @param  `e`  A Pixi InteractionEvent
-   */
-  _pointerdown(e) {
-    if (this.lastDown) return;  // a pointer is already down
+	_pointerdown(e) {
+		if (this.lastDown) {
+			return;
+		}
 
-    const down = this._getEventData(e);
-    this.lastDown = down;
-    this.lastClick = null;
-    this.emit('down', down);
-  }
+		const down = this._getEventData(e);
+		this.lastDown = down;
+		this.lastClick = null;
+		this.emit('down', down);
+	}
 
 
-  /**
-   * _pointermove
-   * Handler for pointermove events.
-   * @param  `e`  A Pixi InteractionEvent
-   */
-  _pointermove(e) {
-    const move = this._getEventData(e);
-    this.lastMove = move;
+	_pointermove(e) {
+		const move = this._getEventData(e);
+		this.lastMove = move;
 
-    // After spacebar click, user must move pointer or lift spacebar to allow another spacebar click
-    if (this._spaceClickDisabled && this.lastSpace) {
-      const dist = vecLength(move.coord.screen, this.lastSpace.coord.screen);
-      if (dist > FAR_TOLERANCE) {     // pointer moved far enough
-        this._spaceClickDisabled = false;
-      }
-    }
+		if (this._spaceClickDisabled && this.lastSpace) {
+			const dist = vecLength(move.coord.screen, this.lastSpace.coord.screen);
+			if (dist > FAR_TOLERANCE) {
+				this._spaceClickDisabled = false;
+			}
+		}
 
-    // If the pointer moves too much, we consider it as a drag, not a click, and set `isCancelled=true`
-    const down = this.lastDown;
-    if (down && !down.isCancelled && down.id === move.id) {
-      const dist = vecLength(down.coord.screen, move.coord.screen);
-      if (dist >= NEAR_TOLERANCE) {
-        down.isCancelled = true;
-      }
-    }
+		const down = this.lastDown;
+		if (down && !down.isCancelled && down.id === move.id) {
+			const dist = vecLength(down.coord.screen, move.coord.screen);
+			if (dist >= NEAR_TOLERANCE) {
+				down.isCancelled = true;
+			}
+		}
 
-    this._doMove();
-  }
+		this._doMove();
+	}
 
 
-  /**
-   * _pointerup
-   * Handler for pointerup events.
-   * @param  `e`  A Pixi InteractionEvent
-   */
-  _pointerup(e) {
-    const down = this.lastDown;
-    const up = this._getEventData(e);
-    if (!down || down.id !== up.id) return;  // not down, or different pointer
+	_pointerup(e) {
+		const down = this.lastDown;
+		const up = this._getEventData(e);
 
-    this.lastDown = null;  // prepare for the next `pointerdown`
+		if (!down || down.id !== up.id) {
+			return;
+		}
 
-    if (down.isCancelled) return;   // was cancelled already by moving too much
+		this.lastDown = null;
 
-    const dist = vecLength(down.coord.screen, up.coord.screen);
-    if (dist < NEAR_TOLERANCE || (dist < FAR_TOLERANCE && up.time - down.time < 500)) {
-      this.lastClick = up;  // We will accept this as a click
-      this._doClick();
-    }
-  }
+		if (down.isCancelled) {
+			return;
+		}
 
-
-  /**
-   * _pointercancel
-   * Handler for pointercancel events.
-   * @param  `e`  A Pixi InteractionEvent
-   */
-  _pointercancel() {
-    this.lastDown = null;  // prepare for the next `pointerdown`
-  }
+		const dist = vecLength(down.coord.screen, up.coord.screen);
+		if (dist < NEAR_TOLERANCE || (dist < FAR_TOLERANCE && up.time - down.time < 500)) {
+			this.lastClick = up;
+			this._doClick();
+		}
+	}
 
 
-  /**
-   * _spacebar
-   * Handler for `keydown` events of the spacebar. We use these to simulate clicks.
-   * Note that the spacebar will repeat, so we can get many of these.
-   */
-  _spacebar() {
-    if (this._spaceClickDisabled) return;
-
-    // For spacebar clicks we will use the last move event as the trigger
-    if (!this.lastMove) return;
-
-    // Becase spacebar events will repeat if you keep it held down,
-    // user must move pointer or lift spacebar to allow another spacebar click.
-    // So we disable further spacebar clicks until one of those things happens.
-    this._spaceClickDisabled = true;
-    this.lastSpace = this.lastMove;
-    this.lastClick = this.lastMove;   // We will accept this as a click
-    this._doClick();
-  }
+	_pointercancel() {
+		this.lastDown = null;
+	}
 
 
-  /**
-   * _doMove
-   * Checks lastMove and emits a 'move' event if needed.
-   * This may also be fired if we detect a change in the modifier keys.
-   */
-  _doMove() {
-    if (!this._enabled || !this.lastMove) return;  // nothing to do
+	_spacebar() {
+		if (this._spaceClickDisabled) {
+			return;
+		}
+		if (!this.lastMove) {
+			return;
+		}
 
-    // Ignore it if we are not over the canvas
-    // (e.g. sidebar, out of browser window, over a button, toolbar, modal)
-    const context = this.context;
-    const eventManager = context.systems.gfx.events;
-    if (!eventManager.pointerOverRenderer) return;
-
-    const modifiers = eventManager.modifierKeys;
-    const isMac = utilDetect().os === 'mac';
-    const disableSnap = modifiers.has('Alt') || modifiers.has('Meta') || (!isMac && modifiers.has('Control'));
-    const eventData = Object.assign({}, this.lastMove);  // shallow copy
-
-    // Handle situations where we don't want to hover a target way...
-    let isActiveTarget = false;
-//    if (eventData?.target?.layerID === 'osm') {
-//      const mode = context.mode;
-//      const target = eventData?.target?.data || null;
-//      let activeID;
-//      if (mode?.id === 'draw-line') {
-//        activeID = mode.drawNode?.id;
-//      } else if (mode?.id === 'drag-node') {
-//        activeID = mode.dragNode?.id;
-//      }
-//
-//      // If a node being interacted with is on a way being tageted..
-//      if (activeID && target?.type === 'way') {
-//        const activeIndex = target.nodes.indexOf(activeID);
-//        if (activeIndex !== -1) {
-//          isActiveTarget = true;
-//          const graph = context.systems.editor.staging.graph;
-//          const viewport = context.viewport;
-//          const choice = geoChooseEdge(graph.childNodes(target), eventData.coord.map, viewport, activeID);
-//
-//          const SNAP_DIST = 6;  // hack to avoid snap to fill, see #719
-//          if (choice && choice.distance < SNAP_DIST) {
-//            // We should not target parts of the way that are adjacent ot the active node
-//            // but we can target segments of the way that are >2 segments away.
-//            if ((choice.index > activeIndex + 2) || (choice.index < activeIndex - 1)) {
-//              isActiveTarget = false;
-//              eventData.target.choice = choice;
-//            }
-//          }
-//        }
-//      }
-//    }
-
-    // If a modifier key is down, discard the target to prevent snap/hover.
-    if (disableSnap || isActiveTarget) {
-      eventData.target = null;
-    }
-
-    this.emit('move', eventData);
-  }
+		this._spaceClickDisabled = true;
+		this.lastSpace = this.lastMove;
+		this.lastClick = this.lastMove;
+		this._doClick();
+	}
 
 
-  /**
-   * _doClick
-   * Checks lastClick and emits a 'click' event if needed
-   */
-  _doClick() {
-    if (!this._enabled || !this.lastClick) return;  // nothing to do
+	_doMove() {
+		if (!this._enabled || !this.lastMove) {
+			return;
+		}
 
-    // Ignore it if we are not over the canvas
-    // (e.g. sidebar, out of browser window, over a button, toolbar, modal)
-    const context = this.context;
-    const eventManager = context.systems.gfx.events;
-    // if (!eventManager.pointerOverRenderer) return;
+		const context = this.context;
+		const eventManager = context.systems.gfx.events;
 
-    const modifiers = eventManager.modifierKeys;
-    const isMac = utilDetect().os === 'mac';
-    const disableSnap = modifiers.has('Alt') || modifiers.has('Meta') || (!isMac && modifiers.has('Control'));
-    const eventData = Object.assign({}, this.lastClick);  // shallow copy
+		if (!eventManager.pointerOverRenderer) {
+			return;
+		}
 
-    // Handle situations where we don't want to hover a target way...
-    let isActiveTarget = false;
-//    if (eventData?.target?.layerID === 'osm') {
-//      const mode = context.mode;
-//      const target = eventData?.target?.data || null;
-//      let activeID;
-//      if (mode?.id === 'draw-line') {
-//        activeID = mode.drawNode?.id;
-//      } else if (mode?.id === 'drag-node') {
-//        activeID = mode.dragNode?.id;
-//      }
-//
-//      // If a node being interacted with is on a way being tageted..
-//      if (activeID && target?.type === 'way') {
-//        const activeIndex = target.nodes.indexOf(activeID);
-//        if (activeIndex !== -1) {
-//          isActiveTarget = true;
-//          const graph = context.systems.editor.staging.graph;
-//          const viewport = context.viewport;
-//          const choice = geoChooseEdge(graph.childNodes(target), eventData.coord.map, viewport, activeID);
-//
-//          const SNAP_DIST = 6;  // hack to avoid snap to fill, see #719
-//          if (choice && choice.distance < SNAP_DIST) {
-//            // We should not target parts of the way that are adjacent ot the active node
-//            // but we can target segments of the way that are >2 segments away.
-//            if ((choice.index > activeIndex + 2) || (choice.index < activeIndex - 1)) {
-//              isActiveTarget = false;
-//              eventData.target.choice = choice;
-//            }
-//          }
-//        }
-//      }
-//    }
+		const modifiers = eventManager.modifierKeys;
+		const isMac = utilDetect().os === 'mac';
+		const disableSnap = modifiers.has('Alt') || modifiers.has('Meta') || (!isMac && modifiers.has('Control'));
 
-    // If a modifier key is down, discard the target to prevent snap/hover.
-    if (disableSnap || isActiveTarget) {
-      eventData.target = null;
-    }
+		// Shallow-copy eventData so we can attach snapResult without mutating lastMove
+		const eventData = Object.assign({}, this.lastMove);
+		eventData.snapResult = null;
 
-    this.emit('click', eventData);
-  }
+		if (!disableSnap) {
+			eventData.snapResult = SnapSystem.GetLocationToSnapTo(this.lastMove, context);
+		}
 
+		this.emit('move', eventData);
+	}
+
+
+	_doClick() {
+		if (!this._enabled || !this.lastClick) {
+			return;
+		}
+
+		const context = this.context;
+		const eventManager = context.systems.gfx.events;
+		const modifiers = eventManager.modifierKeys;
+		const isMac = utilDetect().os === 'mac';
+		const disableSnap = modifiers.has('Alt') || modifiers.has('Meta') || (!isMac && modifiers.has('Control'));
+
+		// Shallow-copy eventData so we can attach snapResult without mutating lastClick.
+		// Use lastMove as the snap source — it has the correct Pixi target state.
+		// lastClick comes from pointerup whose raw Pixi target may differ.
+		const eventData = Object.assign({}, this.lastClick);
+		eventData.snapResult = null;
+
+		const snapSource = this.lastMove || this.lastClick;
+
+		if (!disableSnap && snapSource) {
+			eventData.snapResult = SnapSystem.GetLocationToSnapTo(
+				snapSource,
+				context,
+			);
+		}
+
+		this.emit('click', eventData);
+	}
 }

--- a/modules/core/SnapSystem.js
+++ b/modules/core/SnapSystem.js
@@ -1,0 +1,89 @@
+import { geoChooseEdge } from '../geo/index.js';
+
+export class SnapSystem {
+
+	static GetLocationToSnapTo(eventData, context) {
+		if (eventData == null) {
+			return null;
+		}
+
+		const editor = context.systems.editor;
+		const graph = editor.staging.graph;
+		const viewport = context.viewport;
+		const screenCoords = eventData.coord.map;
+		const worldCoords = viewport.unproject(screenCoords);
+
+		if (eventData.target != null) {
+			const datum = eventData.target.data;
+
+			if (datum != null) {
+				const target = graph.hasEntity(datum.id);
+
+				if (target != null) {
+
+					if (target.type === 'node') {
+						return {
+							type: 'node',
+							data: target,
+							loc: target.loc,
+							edge: null
+						};
+					}
+
+					else if (target.type === 'way') {
+						const result = SnapSystem._trySnapToWay(
+							target, screenCoords, graph, viewport
+						);
+
+						if (result !== null) {
+							return result;
+						}
+					}
+				}
+			}
+		}
+
+		// Free placement
+		return {
+			type: 'free',
+			data: null,
+			loc: worldCoords,
+			edge: null
+		};
+	}
+
+
+	static _trySnapToWay(way, screenCoords, graph, viewport) {
+		const chosenEdge = geoChooseEdge(
+			graph.childNodes(way),
+			screenCoords,
+			viewport
+		);
+
+		const maxSnapDistance = 20;
+
+		if (chosenEdge == null) {
+			return null;
+		}
+
+		if (chosenEdge.distance == null || chosenEdge.distance <= 0) {
+			return null;
+		}
+
+		if (chosenEdge.distance >= maxSnapDistance) {
+			return null;
+		}
+
+		const edge = [
+			way.nodes[chosenEdge.index - 1],
+			way.nodes[chosenEdge.index]
+		];
+
+		return {
+			type: 'way',
+			data: way,
+			loc: chosenEdge.loc,
+			edge: edge
+		};
+	}
+}

--- a/modules/modes/AddPointMode.js
+++ b/modules/modes/AddPointMode.js
@@ -3,189 +3,243 @@ import { AbstractMode } from './AbstractMode.js';
 import { actionAddEntity } from '../actions/add_entity.js';
 import { actionChangeTags } from '../actions/change_tags.js';
 import { actionAddMidpoint } from '../actions/add_midpoint.js';
-import { geoChooseEdge } from '../geo/index.js';
 import { osmNode } from '../osm/node.js';
+import { actionMoveNode } from '../actions/move_node.js';
 
 const DEBUG = false;
 
 
-/**
- * `AddPointMode`
- * In this mode, we are waiting for the user to place a point somewhere
- */
 export class AddPointMode extends AbstractMode {
 
-  /**
-   * @constructor
-   * @param  `context`  Global shared application context
-   */
-  constructor(context) {
-    super(context);
-    this.id = 'add-point';
+	constructor(context) {
+		super(context);
+		this.id = 'add-point';
 
-    this.defaultTags = {};
+		this.defaultTags = {};
 
-    // Make sure the event handlers have `this` bound correctly
-    this._click = this._click.bind(this);
-    this._cancel = this._cancel.bind(this);
-  }
+		this._click = this._click.bind(this);
+		this._cancel = this._cancel.bind(this);
+		this._onCursorMovement = this._onCursorMovement.bind(this);
 
-
-  /**
-   * enter
-   * Enters the mode.
-   */
-  enter() {
-    if (DEBUG) {
-      console.log('AddPointMode: entering');  // eslint-disable-line no-console
-    }
-
-    this._active = true;
-    const context = this.context;
-
-    const eventManager = context.systems.gfx.events;
-    eventManager.setCursor('crosshair');
-
-    context.enableBehaviors(['hover', 'draw', 'mapInteraction']);
-    context.behaviors.draw
-      .on('click', this._click)
-      .on('cancel', this._cancel)
-      .on('finish', this._cancel);
-
-    return true;
-  }
+		this._previewNodeID = null;
+		this._lastSnapResult = null;
+	}
 
 
-  /**
-   * exit
-   */
-  exit() {
-    if (!this._active) return;
-    this._active = false;
+	enter() {
+		if (DEBUG) {
+			console.log('AddPointMode: entering');
+		}
 
-    if (DEBUG) {
-      console.log('AddPointMode: exiting');  // eslint-disable-line no-console
-    }
+		const context = this.context;
+		const editor = context.systems.editor;
+		const map = context.systems.map;
 
-    const context = this.context;
+		this._active = true;
+		this._previewNodeID = null;
+		this._lastSnapResult = null;
 
-    const eventManager = context.systems.gfx.events;
-    eventManager.setCursor('grab');
+		const startLoc = map.mouseLoc();
+		const previewNode = osmNode({ loc: startLoc, tags: this.defaultTags });
 
-    context.behaviors.draw
-      .off('click', this._click)
-      .off('cancel', this._cancel)
-      .off('finish', this._cancel);
-  }
+		editor.perform(actionAddEntity(previewNode));
+		this._previewNodeID = previewNode.id;
 
+		// Mark the preview node with the 'drawing' class so the Pixi renderer
+		// treats it as non-interactive. Without this, the preview node sits on
+		// top of ways and intercepts Pixi hit tests, preventing way snapping.
+		// DrawLineMode uses the same approach for its temporary draw node.
+		const gfx = context.systems.gfx;
+		const layer = gfx.scene.layers.get('osm');
+		if (layer) {
+			layer.setClass('drawing', previewNode.id);
+		}
 
-  /**
-   * _click
-   * Process whatever the user clicked on
-   */
-  _click(eventData) {
-    const context = this.context;
-    const editor = context.systems.editor;
-    const graph = editor.staging.graph;
-    const locations = context.systems.locations;
-    const viewport = context.viewport;
-    const point = eventData.coord.map;
-    const loc = viewport.unproject(point);
-    if (locations.blocksAt(loc).length) return;   // editing is blocked here
+		const eventManager = context.systems.gfx.events;
+		eventManager.setCursor('crosshair');
 
-    // Allow snapping only for OSM Entities in the actual graph (i.e. not Rapid features)
-    const datum = eventData?.target?.data;
-    const choice = eventData?.target?.choice;
-    const target = datum && graph.hasEntity(datum.id);
+		context.enableBehaviors(['hover', 'draw', 'mapInteraction']);
 
-    // Snap to a node
-    if (target?.type === 'node') {
-      this._clickNode(target.loc, target);
-      return;
-    }
+		context.behaviors.draw
+			.on('click', this._click)
+			.on('cancel', this._cancel)
+			.on('finish', this._cancel)
+			.on('move', this._onCursorMovement);
 
-    // Snap to a way
-//    if (target?.type === 'way' && choice) {
-//      const edge = [ target.nodes[choice.index - 1], target.nodes[choice.index] ];
-//      this._clickWay(choice.loc, edge);
-//      return;
-//    }
-    if (target?.type === 'way') {
-      const choice = geoChooseEdge(graph.childNodes(target), point, viewport);
-      const SNAP_DIST = 6;  // hack to avoid snap to fill, see #719
-      if (choice && choice.distance < SNAP_DIST) {
-        const edge = [target.nodes[choice.index - 1], target.nodes[choice.index]];
-        this._clickWay(choice.loc, edge);
-        return;
-      }
-    }
-    this._clickNothing(loc);
-  }
+		return true;
+	}
 
 
-  /**
-   * _click
-   * Clicked on nothing, create the point at given `loc`
-   */
-  _clickNothing(loc) {
-    const context = this.context;
-    const editor = context.systems.editor;
-    const l10n = context.systems.l10n;
+	exit() {
+		if (!this._active) {
+			return;
+		}
 
-    const node = osmNode({ loc: loc, tags: this.defaultTags });
+		this._active = false;
 
-    editor.perform(actionAddEntity(node));
-    editor.commit({ annotation: l10n.t('operations.add.annotation.point'), selectedIDs: [node.id] });
-    context.enter('select-osm', { selection: { osm: [node.id] }, newFeature: true });
-  }
+		if (DEBUG) {
+			console.log('AddPointMode: exiting');
+		}
 
+		const context = this.context;
+		const editor = context.systems.editor;
+		const eventManager = context.systems.gfx.events;
 
-  /**
-   * _clickWay
-   * Clicked on an existing way, add a midpoint along the `edge` at given `loc`
-   */
-  _clickWay(loc, edge) {
-    const context = this.context;
-    const editor = context.systems.editor;
-    const l10n = context.systems.l10n;
+		eventManager.setCursor('grab');
 
-    const node = osmNode({ tags: this.defaultTags });
-    editor.perform(actionAddMidpoint({ loc: loc, edge: edge }, node));
-    editor.commit({ annotation: l10n.t('operations.add.annotation.vertex'), selectedIDs: [node.id] });
-    context.enter('select-osm', { selection: { osm: [node.id] }, newFeature: true });
-  }
+		const gfx = context.systems.gfx;
+		const layer = gfx.scene.layers.get('osm');
+		if (layer) {
+			layer.clearClass('drawing');
+		}
 
+		context.behaviors.draw
+			.off('click', this._click)
+			.off('cancel', this._cancel)
+			.off('finish', this._cancel)
+			.off('move', this._onCursorMovement);
 
-  /**
-   * _clickNode
-   * Clicked on an existing node, merge `defaultTags` into it, if any, then select the node
-   */
-  _clickNode(loc, node) {
-    const context = this.context;
-    const editor = context.systems.editor;
-    const l10n = context.systems.l10n;
-
-    if (Object.keys(this.defaultTags).length === 0) {
-      context.enter('select-osm', { selection: { osm: [node.id] }, newFeature: false });
-      return;
-    }
-
-    const tags = Object.assign({}, node.tags);  // shallow copy
-    for (const k in this.defaultTags) {
-      tags[k] = this.defaultTags[k];
-    }
-
-    editor.perform(actionChangeTags(node.id, tags));
-    editor.commit({ annotation: l10n.t('operations.add.annotation.point'), selectedIDs: [node.id] });
-    context.enter('select-osm', { selection: { osm: [node.id] }, newFeature: false });
-  }
+		// _previewNodeID is null if _click already handled cleanup.
+		// Only revert if the user cancelled — preview node still in staging.
+		if (this._previewNodeID !== null) {
+			this._previewNodeID = null;
+			this._lastSnapResult = null;
+			editor.revert();
+		}
+	}
 
 
-  /**
-   * _cancel
-   * Return to browse mode without doing anything
-   */
-  _cancel() {
-    this.context.enter('browse');
-  }
+	_onCursorMovement(eventData) {
+		if (this._previewNodeID === null) {
+			return;
+		}
+
+		const context = this.context;
+		const editor = context.systems.editor;
+
+		// Cache snap result for use in _click
+		this._lastSnapResult = eventData.snapResult;
+
+		let worldLoc = null;
+
+		if (eventData.snapResult !== null && eventData.snapResult !== undefined) {
+			// snapResult.loc is world coords from SnapSystem
+			worldLoc = eventData.snapResult.loc;
+		}
+		else {
+			worldLoc = context.viewport.unproject(eventData.coord.map);
+		}
+
+		editor.perform(actionMoveNode(this._previewNodeID, worldLoc));
+		context.systems.gfx.immediateRedraw();
+	}
+
+
+	_click(eventData) {
+		const context = this.context;
+		const editor = context.systems.editor;
+
+		// Use snap from click event, fall back to last cached move snap
+		const snap = eventData.snapResult || this._lastSnapResult;
+
+		// Null out before revert so exit() skips the revert
+		this._previewNodeID = null;
+		this._lastSnapResult = null;
+
+		// Revert wipes the preview node from staging.
+		// Stable is untouched — previously committed nodes are safe.
+		editor.revert();
+
+		if (snap !== null) {
+			if (snap.type === 'way') {
+				this._placeOnWay(snap.loc, snap.edge);
+				return;
+			}
+
+			if (snap.type === 'node') {
+				this._placeOnNode(snap.data);
+				return;
+			}
+		}
+
+		// Free placement
+		const freeLoc = snap ? snap.loc : context.viewport.unproject(eventData.coord.map);
+		this._placeFree(freeLoc);
+	}
+
+
+	_placeFree(loc) {
+		const context = this.context;
+		const editor = context.systems.editor;
+		const l10n = context.systems.l10n;
+
+		const node = osmNode({ loc: loc, tags: this.defaultTags });
+		editor.perform(actionAddEntity(node));
+		editor.commit({
+			annotation: l10n.t('operations.add.annotation.point'),
+			selectedIDs: [node.id]
+		});
+
+		context.enter('select-osm', {
+			selection: { osm: [node.id] },
+			newFeature: true
+		});
+	}
+
+
+	_placeOnWay(loc, edge) {
+		const context = this.context;
+		const editor = context.systems.editor;
+		const l10n = context.systems.l10n;
+
+		const node = osmNode({ tags: this.defaultTags });
+		editor.perform(actionAddMidpoint({ loc: loc, edge: edge }, node));
+		editor.commit({
+			annotation: l10n.t('operations.add.annotation.vertex'),
+			selectedIDs: [node.id]
+		});
+
+		context.enter('select-osm', {
+			selection: { osm: [node.id] },
+			newFeature: true
+		});
+	}
+
+
+	_placeOnNode(existingNode) {
+		const context = this.context;
+		const editor = context.systems.editor;
+		const l10n = context.systems.l10n;
+
+		if (Object.keys(this.defaultTags).length === 0) {
+			context.enter('select-osm', {
+				selection: { osm: [existingNode.id] },
+				newFeature: false
+			});
+			return;
+		}
+
+		const tags = Object.assign({}, existingNode.tags);
+
+		for (const k in this.defaultTags) {
+			tags[k] = this.defaultTags[k];
+		}
+
+		editor.perform(actionChangeTags(existingNode.id, tags));
+		editor.commit({
+			annotation: l10n.t('operations.add.annotation.point'),
+			selectedIDs: [existingNode.id]
+		});
+
+		context.enter('select-osm', {
+			selection: { osm: [existingNode.id] },
+			newFeature: false
+		});
+	}
+
+
+	_cancel() {
+		// exit() will revert since _previewNodeID is still set
+		this.context.enter('browse');
+	}
 }


### PR DESCRIPTION
This is my first open source contribution, so I appreciate any feedback on the implementation.

Fixes #719 — when placing a point, there was no visual preview showing where the point would land before clicking, making snapping to ways and nodes unintuitive.

Changes:

- Added modules/core/SnapSystem.js — a utility that computes snap targets (ways, nodes, free placement) from pointer event data. Extracted as a reusable class so other modes could potentially use it.

- Modified AddPointMode.js to show a live preview node that follows the cursor and snaps to nearby features before the user clicks. The preview is created in staging and removed via editor.revert() on click or cancel.

- Modified DrawBehavior.js to run snap detection on move and click events, attaching the result as eventData.snapResult. The original eventData fields are left unmodified so existing behavior in DrawLineMode and other consumers is unaffected.

The preview node is marked with the drawing class so the Pixi renderer treats it as non-interactive, preventing it from intercepting hit tests on underlying ways.