### PR TITLE
Preserve Rapid accept self-merge endpoints

### DIFF
--- a/modules/actions/rapid_accept_feature.js
+++ b/modules/actions/rapid_accept_feature.js
@@ -177,13 +177,15 @@ export function actionRapidAcceptFeature(entityID, extGraph, tree) {
             var connectedHighwayTag = graph.entity(bestResult.targetWayId).tags.highway;
 
             if (bestResult.mergeNodeId) {
-                // Replace endpoint references in accepted way with existing node
-                var updatedNodes = acceptedWay.nodes.map(function(nid) {
-                    return nid === node.id ? bestResult.mergeNodeId : nid;
-                });
-                graph = graph.replace(acceptedWay.update({ nodes: updatedNodes }));
-                // Remove the orphaned original node
-                graph = graph.remove(node);
+                if (bestResult.mergeNodeId !== node.id) {
+                    // Replace endpoint references in accepted way with existing node
+                    var updatedNodes = acceptedWay.nodes.map(function(nid) {
+                        return nid === node.id ? bestResult.mergeNodeId : nid;
+                    });
+                    graph = graph.replace(acceptedWay.update({ nodes: updatedNodes }));
+                    // Remove the orphaned original node
+                    graph = graph.remove(node);
+                }
             } else {
                 // Snap node to projected point on segment, splice into target way
                 node = node.move(bestResult.snapLoc);

--- a/test/unit/actions/rapid_accept_feature.test.js
+++ b/test/unit/actions/rapid_accept_feature.test.js
@@ -151,6 +151,29 @@ describe('actionRapidAcceptFeature', () => {
         });
 
 
+        it('preserves shared endpoint when accepting connected Rapid ways', () => {
+            const tree = new Rapid.Tree(new Rapid.Graph());
+
+            const smallN1 = Rapid.osmNode({ id: 'n-27', loc: [0, 0] });
+            const sharedNode = Rapid.osmNode({ id: 'n-28', loc: [1, 0] });
+            const smallWay = Rapid.osmWay({ id: 'w-4', nodes: ['n-27', 'n-28'], tags: { highway: 'residential' } });
+            const smallExtGraph = new Rapid.Graph([smallN1, sharedNode, smallWay]);
+
+            let graph = Rapid.actionRapidAcceptFeature('w-4', smallExtGraph, tree)(new Rapid.Graph());
+            assert.ok(graph.hasEntity('n-28'), 'shared endpoint should exist after accepting first way');
+
+            const largeN2 = Rapid.osmNode({ id: 'n-29', loc: [2, 0] });
+            const largeWay = Rapid.osmWay({ id: 'w-5', nodes: ['n-28', 'n-29'], tags: { highway: 'tertiary' } });
+            const largeExtGraph = new Rapid.Graph([sharedNode, largeN2, largeWay]);
+
+            graph = Rapid.actionRapidAcceptFeature('w-5', largeExtGraph, tree)(graph);
+
+            assert.ok(graph.hasEntity('n-28'), 'shared endpoint should not be removed by self-merge');
+            assert.deepEqual(graph.childNodes(graph.entity('w-4')).map(node => node.id), ['n-27', 'n-28']);
+            assert.deepEqual(graph.childNodes(graph.entity('w-5')).map(node => node.id), ['n-28', 'n-29']);
+        });
+
+
         it('merges instead of creating duplicate when projection lands on existing node', () => {
             const { osmGraph, tree } = buildOsmScene(makeHighway());
 


### PR DESCRIPTION
## Summary

Fixes #1813.

When accepting connected Rapid/Overture roads, endpoint auto-connect can select the endpoint node itself as the best merge target. In that self-merge case the node is already the shared endpoint between accepted ways, not an orphaned duplicate.

This PR skips duplicate-node replacement/removal when `bestResult.mergeNodeId === node.id`, while keeping the existing behavior for true duplicate endpoint merges.

## Root Cause

The bug was introduced in #1769 by commit `9a2e029087de9903291e9b20431cbcc75c611008` (`Auto connect new ways, inherit classification`). That commit added the endpoint auto-connect merge path and unconditionally removed the endpoint node after replacing accepted-way references with `bestResult.mergeNodeId`.

If the merge target is the endpoint itself, that replacement is a no-op and the subsequent removal deletes the shared node out from under previously accepted connected ways.

## Testing

- `./node_modules/.bin/dotenvx run --quiet -- node --experimental-test-coverage --test-reporter spec --test test/unit/actions/rapid_accept_feature.test.js`
