### PR TITLE
Limit Pixi atlas size

### DIFF
--- a/modules/pixi/PixiTextures.js
+++ b/modules/pixi/PixiTextures.js
@@ -72,20 +72,9 @@ export class PixiTextures {
     const renderer = gfx.pixi.renderer;
     registerAtlasUploader(renderer);
 
-    // Try to get the max texture size.
-    // We will prefer large atlas size of 8192 to avoid texture swapping, but can settle for less.
-    const trysize = 8192;
-    let maxsize = 2048;   // a reasonable default
-    if (gfx.highQuality) {
-      if (renderer.type === PIXI.RendererType.WEBGL) {
-        const gl = renderer.gl;
-        maxsize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-      } else if (renderer.type === PIXI.RendererType.WEBGPU) {
-        const gpu = renderer.gpu;
-        maxsize = gpu.adapter.limits.maxTextureDimension2D;
-      }
-    }
-    const size = Math.min(trysize, maxsize);
+    // Pixi's WebGL shaders use mediump fragment UVs, which only guarantee about
+    // 10 bits of precision and cannot reliably address larger normalized atlases.
+    const size = 2048;
 
     // We store textures in 3 atlases, each one is for holding similar sized things.
     // Each "atlas" manages its own store of "TextureSources" - real textures that upload to the GPU.


### PR DESCRIPTION
## Summary
- Cap Rapid's Pixi texture atlases at 2048px instead of growing them to the renderer's max texture size.
- Remove the max-texture-size probing because the atlas size is now intentionally fixed.
- Add a comment explaining that Pixi's current WebGL shaders use mediump fragment UVs, which cannot reliably address larger normalized atlases on true-mediump GPUs.

Closes #1815

## Why
Issue #1815 reported severely pixelated imagery on an Ubuntu ARM/Snapdragon X system. The canvas/DPR setup was correct, and bypassing Rapid's atlas path with direct Pixi textures made imagery render sharply. Capping Rapid's atlas size fixed the visible pixelation.

The reduced repro points to large normalized atlas coordinates being sampled through Pixi's WebGL shader path with mediump fragment UV precision. mediump only guarantees roughly 10 bits of precision, which is not enough to reliably address large atlases such as 8192x8192 on true-mediump GPUs. Keeping atlases at 2048px avoids relying on precision that WebGL/GLES does not guarantee.

This trades some atlas packing efficiency for correct imagery on affected hardware.

## Testing
- Ran 
> @rapideditor/rapid@2.5.7 build
> run-p build:**


> @rapideditor/rapid@2.5.7 build:data
> shx mkdir -p dist/data && node scripts/build_data.js


> @rapideditor/rapid@2.5.7 build:css
> dotenvx run --quiet -- node scripts/build_css.js


> @rapideditor/rapid@2.5.7 build:bundle:modern:dev
> dotenvx run --quiet -- node config/esbuild.config.modern-dev.js


🏗   Building data...

🏗   Building css...
👍  css built: 104.335ms

👍  data built: 4.148s successfully.

(And also manually previewing Rapid locally)

## Disclosure
Generated by GPT 5.5 with human oversight.